### PR TITLE
Made JsonPath and parse_json_path public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,9 @@
 
 
 use serde_json::{Value};
-use crate::parser::parser::parse_json_path;
+pub use crate::parser::parser::parse_json_path;
 use crate::path::{json_path_instance, PathInstance};
-use crate::parser::model::JsonPath;
+pub use crate::parser::model::JsonPath;
 
 mod parser;
 mod path;


### PR DESCRIPTION
I need access to these lower level components. I want to run the parser once and store the resulting `JsonPath`. Then I will reuse the path to make a `JsonPathFinder` for different instances of `serde_json::Value`.