### PR TITLE
Fix usage of bool and null values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,7 +397,23 @@ mod tests {
          }
      },
      "array":[0,1,2,3,4,5,6,7,8,9],
-     "orders":[{"ref":[1,2,3],"id":1},{"ref":[4,5,6],"id":2},{"ref":[7,8,9],"id":3}],
+     "orders":[
+         {
+             "ref":[1,2,3],
+             "id":1,
+             "filled": true
+         },
+         {
+             "ref":[4,5,6],
+             "id":2,
+             "filled": false
+         },
+         {
+             "ref":[7,8,9],
+             "id":3,
+             "filled": null
+         }
+      ],
      "expensive": 10 }"#
     }
 
@@ -663,6 +679,18 @@ mod tests {
              json_path_value![
                  &sayings,
              ]);
+        let filled_true = json!(1);
+        test(template_json(),
+             "$.orders[?(@.filled == true)].id",
+             json_path_value![
+                 &filled_true,
+             ]);
+        let filled_null = json!(3);
+        test(template_json(),
+            "$.orders[?(@.filled == null)].id",
+            json_path_value![
+                &filled_null,
+            ]);
     }
 
     #[test]

--- a/src/parser/grammar/json_path.pest
+++ b/src/parser/grammar/json_path.pest
@@ -1,5 +1,8 @@
 WHITESPACE = _{ " " | "\t" | "\r\n" | "\n"}
 
+boolean = {"true" | "false"}
+null = {"null"}
+
 min = _{"-"}
 col = _{":"}
 dot =  _{ "." }
@@ -40,7 +43,7 @@ logic = {logic_and ~ ("||" ~ logic_and)*}
 logic_and = {logic_atom ~ ("&&" ~ logic_atom)*}
 logic_atom = {atom ~ (sign ~ atom)? | "(" ~ logic ~ ")"}
 
-atom = {chain | string_qt | number }
+atom = {chain | string_qt | number | boolean | null}
 
 index = {dot? ~ "["~ (unit_keys | unit_indexes | slice | unsigned |filter) ~ "]" }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -155,6 +155,7 @@ fn parse_atom(rule: Pair<Rule>) -> Operand {
         Rule::number => Operand::Static(number_to_value(rule.as_str())),
         Rule::string_qt => Operand::Static(Value::from(down(atom).as_str())),
         Rule::chain => parse_chain_in_operand(down(rule)),
+        Rule::boolean => Operand::Static(rule.as_str().parse().unwrap()),
         _ => Operand::Static(Value::Null)
     }
 }
@@ -342,6 +343,8 @@ mod tests {
     fn index_filter_test() {
         test("[?('abc' == 'abc')]", vec![path!(idx!(?filter!(op!("abc"),"==",op!("abc") )))]);
         test("[?('abc' == 1)]", vec![path!(idx!(?filter!( op!("abc"),"==",op!(1))))]);
+        test("[?('abc' == true)]", vec![path!(idx!(?filter!( op!("abc"),"==",op!(true))))]);
+        test("[?('abc' == null)]", vec![path!(idx!(?filter!( op!("abc"),"==",Operand::Static(Value::Null))))]);
 
         test("[?(@.abc in ['abc','bcd'])]", vec![
             path!(


### PR DESCRIPTION
Fixes usage of `bool` and `null` values.
Jsonpath example: 
```
$.first.second[?(@.active == false)]
```