### PR TITLE
Fix: length() return null when json path does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that  ```$.shop.orders[?(@.active)].id``` and get the result ``` [1,4] ```
 
 ##### Size
 A function `length()` transforms the output of the filtered expression into a size of this element
-It works with arrays, therefore it returns a length of a given array, otherwise 0.
+It works with arrays, therefore it returns a length of a given array, otherwise null.
 
 `$.some_field.length()`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -788,14 +788,14 @@ mod tests {
             JsonPathInst::from_str("$.length()").expect("the path is correct")
         );
         let finder = JsonPathFinder::new(json, path);
-        assert_eq!(finder.find(), json!([0]));
+        assert_eq!(finder.find(), json!([Value::Null]));
 
         let json: Box<Value> = Box::new(json!(1));
         let path: Box<JsonPathInst> = Box::from(
             JsonPathInst::from_str("$.length()").expect("the path is correct")
         );
         let finder = JsonPathFinder::new(json, path);
-        assert_eq!(finder.find(), json!([0]));
+        assert_eq!(finder.find(), json!([Value::Null]));
 
         let json: Box<Value> = Box::new(json!([[1],[2],[3]]));
         let path: Box<JsonPathInst> = Box::from(
@@ -803,5 +803,12 @@ mod tests {
         );
         let finder = JsonPathFinder::new(json, path);
         assert_eq!(finder.find(), json!([3]));
+
+        let json: Box<Value> = Box::new(json!([{"verb": "TEST"},{"verb": "TEST"}, {"verb": "RUN"}]));
+        let path: Box<JsonPathInst> = Box::from(
+            JsonPathInst::from_str("$.not.exist.length()").expect("the path is correct")
+        );
+        let finder = JsonPathFinder::new(json, path);
+        assert_eq!(finder.find(), json!([Value::Null]));
     }
 }

--- a/src/path/top.rs
+++ b/src/path/top.rs
@@ -97,21 +97,26 @@ impl<'a> Path<'a> for FnPath {
 
     fn flat_find(&self, input: Vec<JsonPathValue<'a, Self::Data>>) -> Vec<JsonPathValue<'a, Self::Data>> {
         let len = if input.len() != 1 {
-            input.len()
+            if input == vec![] {
+                json!(Value::Null)
+            }
+            else {
+                json!(input.len())
+            }
         } else {
             match input.get(0) {
-                None => 0,
+                None => json!(Value::Null),
                 Some(v) => {
                     match v {
                         JsonPathValue::NewValue(Array(arr))
-                        | JsonPathValue::Slice(Array(arr)) => arr.len(),
-                        _ => 0
+                        | JsonPathValue::Slice(Array(arr)) => json!(arr.len()),
+                        _ => json!(Value::Null)
                     }
                 }
             }
         };
 
-        vec![JsonPathValue::NewValue(json!(len))]
+        vec![JsonPathValue::NewValue(len)]
     }
 
     fn needs_all(&self) -> bool {


### PR DESCRIPTION
Fixes https://github.com/besok/jsonpath-rust/issues/25