### PR TITLE
Add github actions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.ci]
+failure-output = "immediate-final"
+fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: Rust CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+      - run: cargo clippy --workspace --tests --all-features -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - run: cargo nextest run --all-features --profile ci
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - run: cargo doc --all-features --no-deps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,8 @@
 //!
 //! [`there`]: https://goessner.net/articles/JsonPath/
 
+#![allow(clippy::vec_init_then_push)]
+
 use crate::parser::model::JsonPath;
 use crate::parser::parser::parse_json_path;
 use crate::path::{json_path_instance, PathInstance};
@@ -473,7 +475,7 @@ mod tests {
         test(
             template_json(),
             "$..*.[?(@.isbn)].title",
-            json_path_value![&js1, &js2,&js1, &js2],
+            json_path_value![&js1, &js2, &js1, &js2],
         );
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,8 +1,7 @@
 //! The parser for the jsonpath.
 //! The module grammar denotes the structure of the parsing grammar
 
+mod macros;
 pub(crate) mod model;
 #[allow(clippy::module_inception)]
 pub(crate) mod parser;
-mod macros;
-

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -13,6 +13,7 @@ struct JsonPathParser;
 
 /// the parsing function.
 /// Since the parsing can finish with error the result is [[Result]]
+#[allow(clippy::result_large_err)]
 pub fn parse_json_path(jp_str: &str) -> Result<JsonPath, Error<Rule>> {
     Ok(parse_internal(
         JsonPathParser::parse(Rule::path, jp_str)?.next().unwrap(),

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -48,7 +48,7 @@ pub fn json_path_instance<'a>(json_path: &'a JsonPath, root: &'a Value) -> PathI
         JsonPath::Wildcard => Box::new(Wildcard {}),
         JsonPath::Descent(key) => Box::new(DescentObject::new(key)),
         JsonPath::DescentW => Box::new(DescentWildcard),
-        JsonPath::Current(value) => Box::new(Current::from(&**value, root)),
+        JsonPath::Current(value) => Box::new(Current::from(value, root)),
         JsonPath::Index(index) => process_index(index, root),
         JsonPath::Empty => Box::new(IdentityPath {}),
         JsonPath::Fn(Function::Length) => Box::new(FnPath::Size),

--- a/src/path/top.rs
+++ b/src/path/top.rs
@@ -138,12 +138,12 @@ impl<'a> Path<'a> for DescentWildcard {
     type Data = Value;
 
     fn find(&self, data: JsonPathValue<'a, Self::Data>) -> Vec<JsonPathValue<'a, Self::Data>> {
-        data.map_slice(|data| deep_flatten(data))
+        data.map_slice(deep_flatten)
     }
 }
 
 // todo rewrite to tail rec
-fn deep_flatten<'a>(data: &'a Value) -> Vec<&'a Value> {
+fn deep_flatten(data: &Value) -> Vec<&Value> {
     let mut acc = vec![];
     match data {
         Object(elems) => {
@@ -291,8 +291,6 @@ mod tests {
     use serde_json::json;
     use serde_json::Value;
 
-    use super::deep_path_by_key;
-
     #[test]
     fn object_test() {
         let js = json!({"product": {"key":42}});
@@ -343,7 +341,7 @@ mod tests {
             vec![json_path_value!(&exp_json)]
         );
 
-        let chain = chain!(path!($), field1.clone(), field2.clone(), field3.clone());
+        let chain = chain!(path!($), field1.clone(), field2.clone(), field3);
 
         let path_inst = json_path_instance(&chain, &json);
         let exp_json = json!(42);
@@ -387,7 +385,7 @@ mod tests {
             path!($),
             field1.clone(),
             field2.clone(),
-            field4.clone(),
+            field4,
             path!(union)
         );
         let path_inst = json_path_instance(&chain, &json);
@@ -399,13 +397,7 @@ mod tests {
         );
 
         let union = idx!("field1", "field2");
-        let chain = chain!(
-            path!($),
-            field1.clone(),
-            field2.clone(),
-            field5.clone(),
-            path!(union)
-        );
+        let chain = chain!(path!($), field1.clone(), field2, field5, path!(union));
         let path_inst = json_path_instance(&chain, &json);
         let one = json!("val1");
         let two = json!("val2");


### PR DESCRIPTION
To help with test coverage (#2) it is first important to automate this process for pull requests and also the main branch.

This commit adds a couple of jobs to run with github actions, the minimal CI requirements. A couple of fixes have been applied following the warnings returned by clippy. Most of them were trivial (like clone calls).

Because of the proc macro `json_path_value`, it was necessary to allow globally `#![allow(clippy::vec_init_then_push)]` (`#!`). This is not really convenient as it will certainly disable it for the rest of the library. Unfortunately this rule can't be added to the macro itself. It is triggered because of the use of a mutable vector, clippy doesn't see the expansion of the iterator over `$v`.

Formatting was also fixed but depending on the maintainer opinion it might be reverted for this commit in order to clean the diff and can be let for a subsequent PR.