### PR TITLE
Add continuous delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Rust CI
 on:
   push:
     branches: ["main"]
+    tags: ["v*"]
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -49,3 +50,16 @@ jobs:
           profile: minimal
           toolchain: stable
       - run: cargo doc --all-features --no-deps
+
+  publish:
+    name: publish on crates.io
+    needs:
+      - rustfmt
+      - clippy
+      - test
+      - doc
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo publish -p jsonpath-rust --token ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
By pushing a tag on main the CI will be triggered. The tags must follow the pattern `v*` (e.g v0.1.0) to trigger the publish job.

The `publish` job requires the secret `CRATES_IO_TOKEN` to be configured in the repository settings.

Fixes #35 