### PR TITLE
POC API that avoids clone for consideration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,20 @@ fn test() {
 }
 ```
 
+also, `JsonPathInst` can be used to query the data without cloning.
+```rust
+use serde_json::{json, Value};
+use crate::jsonpath_rust::{JsonPathInst};
+
+fn test() {
+    let json: Value = serde_json::from_str("{}").expect("to get json");
+    let query = JsonPathInst::from_str("$..book[?(@.author size 10)].title").unwrap();
+
+    // To convert to &Value, use deref()
+    assert_eq!(query.find_slice(&json).get(0).expect("to get value").deref(), &json!("Sayings of the Century"));
+}
+```
+
 ### The structure
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,6 @@ impl FromStr for JsonPathInst {
     }
 }
 
-
 impl JsonPathInst {
     pub fn find_slice<'a>(&'a self, value: &'a Value) -> Vec<JsonPtr<'a, Value>> {
         json_path_instance(&self.inner, value)
@@ -215,7 +214,6 @@ impl<'a> Deref for JsonPtr<'a, Value> {
         }
     }
 }
-
 
 impl JsonPathQuery for Box<Value> {
     fn path(self, query: &str) -> Result<Value, String> {
@@ -435,11 +433,11 @@ impl JsonPathFinder {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Deref;
     use crate::JsonPathQuery;
     use crate::JsonPathValue::{NoValue, Slice};
     use crate::{json_path_value, JsonPathFinder, JsonPathInst, JsonPathValue};
     use serde_json::{json, Value};
+    use std::ops::Deref;
     use std::str::FromStr;
 
     fn test(json: &str, path: &str, expected: Vec<JsonPathValue<Value>>) {
@@ -1070,9 +1068,7 @@ mod tests {
 
         // To explicitly convert to &Value, use deref()
         assert_eq!(v.deref(), &json!("Sayings of the Century"));
-
     }
-
 
     // #[test]
     // fn no_value_len_field_test() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl FromStr for JsonPathInst {
 impl JsonPathInst {
     pub fn find_slice<'a>(&'a self, value: &'a Value) -> Vec<JsonPtr<'a, Value>> {
         json_path_instance(&self.inner, value)
-            .find((&(*value)).into())
+            .find(value.into())
             .into_iter()
             .filter(|v| v.has_value())
             .map(|v| match v {
@@ -209,7 +209,7 @@ impl<'a> Deref for JsonPtr<'a, Value> {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            JsonPtr::Slice(v) => *v,
+            JsonPtr::Slice(v) => v,
             JsonPtr::NewValue(v) => v,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,7 +1064,7 @@ mod tests {
         let v = results.get(0).expect("to get value");
 
         // V can be implicitly converted to &Value
-        test_coercion(&v);
+        test_coercion(v);
 
         // To explicitly convert to &Value, use deref()
         assert_eq!(v.deref(), &json!("Sayings of the Century"));


### PR DESCRIPTION
Hi!

I came across this library a while back when I was looking at different jsonpath libraries and it looks nice. The only issue seemed to be that the `JsonPathFinder` API seemed to require cloning to happen, which was a showstopper for my use case. Recently I had cause to look again as the other major jsonpath library for Rust looks abandoned and has bugs.

It looks like the underlying query implementation for `jsonpath-rust `supports query without having to clone the input data, however the use of `JsonPathFinder` forces this to happen.

This PR is a POC API for querying without cloning that introduces a new enum `JsonPtr` for holding values. The reason this has to exist is that `deref` on `JsonPathValue` is not possible without a panic for `NoValue`.

It'd be great if this approach could be considered for this project.

