### PR TITLE
Allow cloning JsonPathInst

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ pub trait JsonPathQuery {
     fn path(self, query: &str) -> Result<Value, String>;
 }
 
+#[derive(Clone)]
 pub struct JsonPathInst {
     inner: JsonPath,
 }


### PR DESCRIPTION
Would be nice to be able to precompile `JsonPath` objects and simply clone them into `JsonPathFinders`. Currently `JsonPath` is cloneable, but `JsonPathInst` (the public API) is not.
