### PR TITLE
Allowing '(' and ')' in regex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Given the json
 | `$..book[2:]`                        | Book number two from tail                                    |
 | `$.store.book[?(@.price < 10)]`      | All books in store cheaper than 10                           |
 | `$..book[?(@.price <= $.expensive)]` | All books in store that are not "expensive"                  |
-| `$..book[?(@.author ~= /.*REES/i)]`  | All books matching regex (ignore case)                       |
+| `$..book[?(@.author ~= '(?i)REES')]` | All books matching regex (ignore case)                       |
 | `$..*`                               | Give me every thing                                          |
 
 ### The library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1228,7 +1228,7 @@ mod tests {
     }
 
     #[test]
-    fn regex_filter_test(){
+    fn regex_filter_test() {
         let json: Box<Value> = Box::new(json!({
             "author":"abcd(Rees)",
         }));
@@ -1238,7 +1238,10 @@ mod tests {
                 .expect("the path is correct"),
         );
         let finder = JsonPathFinder::new(json.clone(), path);
-        assert_eq!(finder.find_slice(),vec![Slice(&json!({"author":"abcd(Rees)"}),"$".to_string())]);
+        assert_eq!(
+            finder.find_slice(),
+            vec![Slice(&json!({"author":"abcd(Rees)"}), "$".to_string())]
+        );
     }
 
     // #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1227,6 +1227,20 @@ mod tests {
         assert_eq!(v, vec![NoValue]);
     }
 
+    #[test]
+    fn regex_filter_test(){
+        let json: Box<Value> = Box::new(json!({
+            "author":"abcd(Rees)",
+        }));
+
+        let path: Box<JsonPathInst> = Box::from(
+            JsonPathInst::from_str("$.[?(@.author ~= '(?i)d\\(Rees\\)')]")
+                .expect("the path is correct"),
+        );
+        let finder = JsonPathFinder::new(json.clone(), path);
+        assert_eq!(finder.find_slice(),vec![Slice(&json!({"author":"abcd(Rees)"}),"$".to_string())]);
+    }
+
     // #[test]
     // fn no_value_len_field_test() {
     //     let json: Box<Value> =

--- a/src/parser/grammar/json_path.pest
+++ b/src/parser/grammar/json_path.pest
@@ -14,7 +14,7 @@ string_qt = ${ "\'" ~ inner ~ "\'" }
 inner = @{ char* }
 char = _{
     !("\"" | "\\" | "\'") ~ ANY
-    | "\\" ~ ("\"" | "\'" |  "\\" | "/" | "b" | "f" | "n" | "r" | "t")
+    | "\\" ~ ("\"" | "\'" |  "\\" | "/" | "b" | "f" | "n" | "r" | "t" | "(" | ")")
     | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
 }
 root = {"$"}
@@ -24,7 +24,7 @@ key_unlim = {"[" ~ string_qt ~ "]"}
 key = ${key_lim | key_unlim}
 
 descent = {dot ~ dot ~ key}
-descent_w = {dot ~ dot ~ "*"} // refactor afterwards 
+descent_w = {dot ~ dot ~ "*"} // refactor afterwards
 wildcard = {dot? ~ "[" ~"*"~"]" | dot ~ "*"}
 current = {"@" ~ chain?}
 field = ${dot? ~ key_unlim | dot ~ key_lim }


### PR DESCRIPTION
Allowing '(' and ')' in regex using '\\(' and '\\)'.
Changed regex syntax in README to match rust regex.
Added a test for regex.