### PR TITLE
Add license info to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "The library provides the basic functionality to find the set of t
 version = "0.3.5"
 authors = ["BorisZhguchev <zhguchev@gmail.com>"]
 edition = "2018"
+license = "MIT"
 license-file = "LICENSE"
 homepage = "https://github.com/besok/jsonpath-rust"
 repository = "https://github.com/besok/jsonpath-rust"


### PR DESCRIPTION
This will add the proper into to crate.io and others