### PR TITLE
export errors and reduce box usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@
 use crate::parser::model::JsonPath;
 use crate::parser::parser::parse_json_path;
 use crate::path::json_path_instance;
+use parser::errors::JsonPathParserError;
 use serde_json::Value;
 use std::convert::TryInto;
 use std::fmt::Debug;
@@ -150,7 +151,8 @@ extern crate pest;
 /// #Note:
 /// the result is going to be cloned and therefore it can be significant for the huge queries
 pub trait JsonPathQuery {
-    fn path(self, query: &str) -> Result<Value, String>;
+    #[allow(clippy::result_large_err)]
+    fn path(self, query: &str) -> Result<Value, JsonPathParserError>;
 }
 
 #[derive(Clone, Debug)]
@@ -159,7 +161,7 @@ pub struct JsonPathInst {
 }
 
 impl FromStr for JsonPathInst {
-    type Err = String;
+    type Err = JsonPathParserError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(JsonPathInst {
@@ -205,7 +207,7 @@ impl<'a> Deref for JsonPtr<'a, Value> {
 }
 
 impl JsonPathQuery for Value {
-    fn path(self, query: &str) -> Result<Value, String> {
+    fn path(self, query: &str) -> Result<Value, JsonPathParserError> {
         let p = JsonPathInst::from_str(query)?;
         Ok(find(&p, &self))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,6 @@ extern crate pest;
 /// #Note:
 /// the result is going to be cloned and therefore it can be significant for the huge queries
 pub trait JsonPathQuery {
-    #[allow(clippy::result_large_err)]
     fn path(self, query: &str) -> Result<Value, JsonPathParserError>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@ impl FromStr for JsonPathInst {
 
 impl JsonPathInst {
     pub fn find_slice<'a>(&'a self, value: &'a Value) -> Vec<JsonPtr<'a, Value>> {
+        use crate::path::Path;
         json_path_instance(&self.inner, value)
             .find(JsonPathValue::from_root(value))
             .into_iter()
@@ -420,6 +421,7 @@ impl<'a, Data> JsonPathValue<'a, Data> {
 /// );
 /// ```
 pub fn find_slice<'a>(path: &'a JsonPathInst, json: &'a Value) -> Vec<JsonPathValue<'a, Value>> {
+    use crate::path::Path;
     let instance = json_path_instance(&path.inner, json);
     let res = instance.find(JsonPathValue::from_root(json));
     let has_v: Vec<JsonPathValue<'_, Value>> = res.into_iter().filter(|v| v.has_value()).collect();

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -1,23 +1,30 @@
-use pest::iterators::Pairs;
 use thiserror::Error;
 
 use super::parser::Rule;
 
 #[derive(Error, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum JsonPathParserError<'a> {
+pub enum JsonPathParserError {
     #[error("Failed to parse rule: {0}")]
     PestError(#[from] pest::error::Error<Rule>),
     #[error("Failed to parse JSON: {0}")]
     JsonParsingError(#[from] serde_json::Error),
-    #[error("{0}")]
-    ParserError(String),
-    #[error("Unexpected rule {0:?} when trying to parse logic atom: {1:?}")]
-    UnexpectedRuleLogicError(Rule, Pairs<'a, Rule>),
-    #[error("Unexpected `none` when trying to parse logic atom: {0:?}")]
-    UnexpectedNoneLogicError(Pairs<'a, Rule>),
-}
-
-pub fn parser_err(cause: &str) -> JsonPathParserError<'_> {
-    JsonPathParserError::ParserError(format!("Failed to parse JSONPath: {cause}"))
+    #[error("Unexpected rule {0:?} when trying to parse logic atom: {1} within {2}")]
+    UnexpectedRuleLogicError(Rule, String, String),
+    #[error("Unexpected `none` when trying to parse logic atom: {0} within {1}")]
+    UnexpectedNoneLogicError(String, String),
+    #[error("Pest returned successful parsing but did not produce any output, that should be unreachable due to .pest definition file: SOI ~ chain ~ EOI")]
+    UnexpectedPestOutput,
+    #[error("expected a `Rule::path` but found nothing")]
+    NoRulePath,
+    #[error("expected a `JsonPath::Descent` but found nothing")]
+    NoJsonPathDescent,
+    #[error("expected a `JsonPath::Field` but found nothing")]
+    NoJsonPathField,
+    #[error("expected a `f64` or `i64`, but got {0}")]
+    InvalidNumber(String),
+    #[error("Invalid toplevel rule for JsonPath: {0:?}")]
+    InvalidTopLevelRule(Rule),
+    #[error("Failed to get inner pairs for {0}")]
+    EmptyInner(String),
 }

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -3,12 +3,9 @@ use thiserror::Error;
 use super::parser::Rule;
 
 #[derive(Error, Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum JsonPathParserError {
     #[error("Failed to parse rule: {0}")]
-    PestError(#[from] pest::error::Error<Rule>),
-    #[error("Failed to parse JSON: {0}")]
-    JsonParsingError(#[from] serde_json::Error),
+    PestError(#[from] Box<pest::error::Error<Rule>>),
     #[error("Unexpected rule {0:?} when trying to parse logic atom: {1} within {2}")]
     UnexpectedRuleLogicError(Rule, String, String),
     #[error("Unexpected `none` when trying to parse logic atom: {0} within {1}")]

--- a/src/parser/model.rs
+++ b/src/parser/model.rs
@@ -2,6 +2,8 @@ use crate::parse_json_path;
 use serde_json::Value;
 use std::convert::TryFrom;
 
+use super::errors::JsonPathParserError;
+
 /// The basic structures for parsing json paths.
 /// The common logic of the structures pursues to correspond the internal parsing structure.
 #[derive(Debug, Clone)]
@@ -35,10 +37,15 @@ impl JsonPath {
 }
 
 impl TryFrom<&str> for JsonPath {
-    type Error = String;
+    type Error = JsonPathParserError;
 
+    /// Parses a string into a [JsonPath].
+    ///
+    /// # Errors
+    ///
+    /// Returns a variant of [JsonPathParserError] if the parsing operation failed.
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        parse_json_path(value).map_err(|e| e.to_string())
+        parse_json_path(value)
     }
 }
 

--- a/src/path/top.rs
+++ b/src/path/top.rs
@@ -1,9 +1,11 @@
 use crate::parser::model::*;
-use crate::path::{json_path_instance, JsonPathValue, Path, PathInstance};
+use crate::path::{json_path_instance, JsonPathValue, Path};
 use crate::JsonPathValue::{NewValue, NoValue, Slice};
 use crate::{jsp_idx, jsp_obj, JsPathStr};
 use serde_json::value::Value::{Array, Object};
 use serde_json::{json, Value};
+
+use super::TopPaths;
 
 /// to process the element [*]
 pub(crate) struct Wildcard {}
@@ -248,12 +250,12 @@ impl<'a> DescentObject<'a> {
 
 /// the top method of the processing representing the chain of other operators
 pub(crate) struct Chain<'a> {
-    chain: Vec<PathInstance<'a>>,
+    chain: Vec<TopPaths<'a>>,
     is_search_length: bool,
 }
 
 impl<'a> Chain<'a> {
-    pub fn new(chain: Vec<PathInstance<'a>>, is_search_length: bool) -> Self {
+    pub fn new(chain: Vec<TopPaths<'a>>, is_search_length: bool) -> Self {
         Chain {
             chain,
             is_search_length,


### PR DESCRIPTION
Hey :)

I did another PR focusing on execution speed and Errors.
 - extended the `JsonPathParserError` error crate with more custom things to get rid of the plain-String errors. This way its easier for libraries to handle errors and catch them.
 - switch the boolean parsing to a own function rather than invoking another json parse.
 - put the pest error in a box (because its 270 bytes long, which means that the Result is very large, even in the good case, because we always need to reserve those bytes to be prepared for the bad case)
 - The function `json_path_instance` returned a `Box<dyn>` which means that the type is determined on runtime, and this is compiled via a vtable. As all posibilities are known i just created a simple enum containing those and implementing the `Path` trait. This allows the compiler to further optimize the crate.
 
 There are a few drawbacks of this change we should consider:
  - I hope i got the Error messages correct, I dont know the parser too well, but i hope they make sense
  - We no longer export the `Pairs` in Error directly, because the lifetimes made problems with `TryFrom` trait, so for now its just the String representation of the `Pairs`
  - I hope the custom `str_to_bool` function can never fail, IMO the path is only `Path::boolean` if the str is either `true` or `false` as described in the .pest file, but I have never worked with that parse, is this assumption true?
   -  to avoid String generation in `parse_logic_or` and `parse_logic_and` functions, i did a check on the len of that iterator. IMO as soon as there is 1 entry, the result cannot be `None` is this correct ? Otherwise I would have introduced a logical bug, but this way we only prepare the Error message on demand`.

So this change needs some good code-review before we just merge it, i don't want to introduce some logic bugs.

On the other hand, the compilation time for a `JsonPathInst` is quite a bit faster now, from over 70 us to under 15us.

I was also thinking about `JsonPath` and `JsonPathInst`, maybe its possible to just use the `JsonPath` in the future, and also move the 3 `find`  methods into this struct. This would definitly be something for another PR, but tell me what you think about it ? Because this PR contains some breaking changes, so we should prob wait with a new release for a bit after merging this.

