### PR TITLE
expose FilterExpression and Operand

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod model;
 pub(crate) mod parser;
 
 pub use errors::JsonPathParserError;
+pub use model::FilterExpression;
 pub use model::JsonPath;
 pub use model::JsonPathIndex;
 pub use parser::{parse_json_path, Rule};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11,4 +11,5 @@ pub use errors::JsonPathParserError;
 pub use model::FilterExpression;
 pub use model::JsonPath;
 pub use model::JsonPathIndex;
+pub use model::Operand;
 pub use parser::{parse_json_path, Rule};


### PR DESCRIPTION
Is it possible to expose `FilterExpression` and `Operand` to traverse the AST for an external crate?

I have suggested the following MR.