### PR TITLE
clippy fix for Rust 1.83.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ pub enum JsonPtr<'a, Data> {
 }
 
 /// Allow deref from json pointer to value.
-impl<'a> Deref for JsonPtr<'a, Value> {
+impl Deref for JsonPtr<'_, Value> {
     type Target = Value;
 
     fn deref(&self) -> &Self::Target {

--- a/src/path/top.rs
+++ b/src/path/top.rs
@@ -111,7 +111,7 @@ impl<'a, T> ObjectField<'a, T> {
     }
 }
 
-impl<'a, T> Clone for ObjectField<'a, T> {
+impl<T> Clone for ObjectField<'_, T> {
     fn clone(&self) -> Self {
         ObjectField::new(self.key)
     }


### PR DESCRIPTION
It seems that the new Rust toolchain no longer allows certain syntax.