### PR TITLE
chore: add RFC9535 compliance test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ pest_derive = "2.0"
 thiserror = "2.0.9"
 
 [dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
 criterion = "0.5.1"
+colored = "2"
 
 [[bench]]
 name = "regex"

--- a/src/fixtures/prepare.sh
+++ b/src/fixtures/prepare.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Use this script to download the RFC9535 compliance suite and prepare it for
+# use in tests.
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+url="https://raw.githubusercontent.com/jsonpath-standard/jsonpath-compliance-test-suite/refs/heads/main/cts.json"
+
+curl -s $url | jq -r '.tests' > "$script_dir/rfc9535-cts.json"

--- a/src/fixtures/rfc9535-cts.json
+++ b/src/fixtures/rfc9535-cts.json
@@ -1,0 +1,10866 @@
+[
+  {
+    "name": "basic, root",
+    "selector": "$",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [
+      [
+        "first",
+        "second"
+      ]
+    ]
+  },
+  {
+    "name": "basic, no leading whitespace",
+    "selector": " $",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "basic, no trailing whitespace",
+    "selector": "$ ",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "basic, name shorthand",
+    "selector": "$.a",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "basic, name shorthand, extended unicode ☺",
+    "selector": "$.☺",
+    "document": {
+      "☺": "A",
+      "b": "B"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "basic, name shorthand, underscore",
+    "selector": "$._",
+    "document": {
+      "_": "A",
+      "_foo": "B"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "basic, name shorthand, symbol",
+    "selector": "$.&",
+    "invalid_selector": true
+  },
+  {
+    "name": "basic, name shorthand, number",
+    "selector": "$.1",
+    "invalid_selector": true
+  },
+  {
+    "name": "basic, name shorthand, absent data",
+    "selector": "$.c",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "result": []
+  },
+  {
+    "name": "basic, name shorthand, array data",
+    "selector": "$.a",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": []
+  },
+  {
+    "name": "basic, wildcard shorthand, object data",
+    "selector": "$.*",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "results": [
+      [
+        "A",
+        "B"
+      ],
+      [
+        "B",
+        "A"
+      ]
+    ]
+  },
+  {
+    "name": "basic, wildcard shorthand, array data",
+    "selector": "$.*",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [
+      "first",
+      "second"
+    ]
+  },
+  {
+    "name": "basic, wildcard selector, array data",
+    "selector": "$[*]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [
+      "first",
+      "second"
+    ]
+  },
+  {
+    "name": "basic, wildcard shorthand, then name shorthand",
+    "selector": "$.*.a",
+    "document": {
+      "x": {
+        "a": "Ax",
+        "b": "Bx"
+      },
+      "y": {
+        "a": "Ay",
+        "b": "By"
+      }
+    },
+    "results": [
+      [
+        "Ax",
+        "Ay"
+      ],
+      [
+        "Ay",
+        "Ax"
+      ]
+    ]
+  },
+  {
+    "name": "basic, multiple selectors",
+    "selector": "$[0,2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      0,
+      2
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, space instead of comma",
+    "selector": "$[0 2]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "basic, selector, leading comma",
+    "selector": "$[,0]",
+    "invalid_selector": true
+  },
+  {
+    "name": "basic, selector, trailing comma",
+    "selector": "$[0,]",
+    "invalid_selector": true
+  },
+  {
+    "name": "basic, multiple selectors, name and index, array data",
+    "selector": "$['a',1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, name and index, object data",
+    "selector": "$['a',1]",
+    "document": {
+      "a": 1,
+      "b": 2
+    },
+    "result": [
+      1
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, index and slice",
+    "selector": "$[1,5:7]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1,
+      5,
+      6
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, index and slice, overlapping",
+    "selector": "$[1,0:3]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1,
+      0,
+      1,
+      2
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, duplicate index",
+    "selector": "$[1,1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1,
+      1
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, wildcard and index",
+    "selector": "$[*,1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      1
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, wildcard and name",
+    "selector": "$[*,'a']",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "results": [
+      [
+        "A",
+        "B",
+        "A"
+      ],
+      [
+        "B",
+        "A",
+        "A"
+      ]
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, wildcard and slice",
+    "selector": "$[*,0:2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      0,
+      1
+    ]
+  },
+  {
+    "name": "basic, multiple selectors, multiple wildcards",
+    "selector": "$[*,*]",
+    "document": [
+      0,
+      1,
+      2
+    ],
+    "result": [
+      0,
+      1,
+      2,
+      0,
+      1,
+      2
+    ]
+  },
+  {
+    "name": "basic, empty segment",
+    "selector": "$[]",
+    "invalid_selector": true
+  },
+  {
+    "name": "basic, descendant segment, index",
+    "selector": "$..[1]",
+    "document": {
+      "o": [
+        0,
+        1,
+        [
+          2,
+          3
+        ]
+      ]
+    },
+    "result": [
+      1,
+      3
+    ]
+  },
+  {
+    "name": "basic, descendant segment, name shorthand",
+    "selector": "$..a",
+    "document": {
+      "o": [
+        {
+          "a": "b"
+        },
+        {
+          "a": "c"
+        }
+      ]
+    },
+    "result": [
+      "b",
+      "c"
+    ]
+  },
+  {
+    "name": "basic, descendant segment, wildcard shorthand, array data",
+    "selector": "$..*",
+    "document": [
+      0,
+      1
+    ],
+    "result": [
+      0,
+      1
+    ]
+  },
+  {
+    "name": "basic, descendant segment, wildcard selector, array data",
+    "selector": "$..[*]",
+    "document": [
+      0,
+      1
+    ],
+    "result": [
+      0,
+      1
+    ]
+  },
+  {
+    "name": "basic, descendant segment, wildcard selector, nested arrays",
+    "selector": "$..[*]",
+    "document": [
+      [
+        [
+          1
+        ]
+      ],
+      [
+        2
+      ]
+    ],
+    "results": [
+      [
+        [
+          [
+            1
+          ]
+        ],
+        [
+          2
+        ],
+        [
+          1
+        ],
+        1,
+        2
+      ],
+      [
+        [
+          [
+            1
+          ]
+        ],
+        [
+          2
+        ],
+        [
+          1
+        ],
+        2,
+        1
+      ]
+    ]
+  },
+  {
+    "name": "basic, descendant segment, wildcard selector, nested objects",
+    "selector": "$..[*]",
+    "document": {
+      "a": {
+        "c": {
+          "e": 1
+        }
+      },
+      "b": {
+        "d": 2
+      }
+    },
+    "results": [
+      [
+        {
+          "c": {
+            "e": 1
+          }
+        },
+        {
+          "d": 2
+        },
+        {
+          "e": 1
+        },
+        1,
+        2
+      ],
+      [
+        {
+          "c": {
+            "e": 1
+          }
+        },
+        {
+          "d": 2
+        },
+        {
+          "e": 1
+        },
+        2,
+        1
+      ],
+      [
+        {
+          "c": {
+            "e": 1
+          }
+        },
+        {
+          "d": 2
+        },
+        2,
+        {
+          "e": 1
+        },
+        1
+      ],
+      [
+        {
+          "d": 2
+        },
+        {
+          "c": {
+            "e": 1
+          }
+        },
+        {
+          "e": 1
+        },
+        1,
+        2
+      ],
+      [
+        {
+          "d": 2
+        },
+        {
+          "c": {
+            "e": 1
+          }
+        },
+        {
+          "e": 1
+        },
+        2,
+        1
+      ],
+      [
+        {
+          "d": 2
+        },
+        {
+          "c": {
+            "e": 1
+          }
+        },
+        2,
+        {
+          "e": 1
+        },
+        1
+      ]
+    ]
+  },
+  {
+    "name": "basic, descendant segment, wildcard shorthand, object data",
+    "selector": "$..*",
+    "document": {
+      "a": "b"
+    },
+    "result": [
+      "b"
+    ]
+  },
+  {
+    "name": "basic, descendant segment, wildcard shorthand, nested data",
+    "selector": "$..*",
+    "document": {
+      "o": [
+        {
+          "a": "b"
+        }
+      ]
+    },
+    "result": [
+      [
+        {
+          "a": "b"
+        }
+      ],
+      {
+        "a": "b"
+      },
+      "b"
+    ]
+  },
+  {
+    "name": "basic, descendant segment, multiple selectors",
+    "selector": "$..['a','d']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      "b",
+      "e",
+      "c",
+      "f"
+    ]
+  },
+  {
+    "name": "basic, descendant segment, object traversal, multiple selectors",
+    "selector": "$..['a','d']",
+    "document": {
+      "x": {
+        "a": "b",
+        "d": "e"
+      },
+      "y": {
+        "a": "c",
+        "d": "f"
+      }
+    },
+    "results": [
+      [
+        "b",
+        "e",
+        "c",
+        "f"
+      ],
+      [
+        "c",
+        "f",
+        "b",
+        "e"
+      ]
+    ]
+  },
+  {
+    "name": "basic, bald descendant segment",
+    "selector": "$..",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, existence, without segments",
+    "selector": "$[?@]",
+    "document": {
+      "a": 1,
+      "b": null
+    },
+    "results": [
+      [
+        1,
+        null
+      ],
+      [
+        null,
+        1
+      ]
+    ]
+  },
+  {
+    "name": "filter, existence",
+    "selector": "$[?@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, existence, present with null",
+    "selector": "$[?@.a]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": null,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals string, single quotes",
+    "selector": "$[?@.a=='b']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals numeric string, single quotes",
+    "selector": "$[?@.a=='1']",
+    "document": [
+      {
+        "a": "1",
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "1",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals string, double quotes",
+    "selector": "$[?@.a==\"b\"]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals numeric string, double quotes",
+    "selector": "$[?@.a==\"1\"]",
+    "document": [
+      {
+        "a": "1",
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "1",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number",
+    "selector": "$[?@.a==1]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals null",
+    "selector": "$[?@.a==null]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": null,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals null, absent from data",
+    "selector": "$[?@.a==null]",
+    "document": [
+      {
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, equals true",
+    "selector": "$[?@.a==true]",
+    "document": [
+      {
+        "a": true,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": true,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals false",
+    "selector": "$[?@.a==false]",
+    "document": [
+      {
+        "a": false,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": false,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals self",
+    "selector": "$[?@==@]",
+    "document": [
+      1,
+      null,
+      true,
+      {
+        "a": "b"
+      },
+      [
+        false
+      ]
+    ],
+    "result": [
+      1,
+      null,
+      true,
+      {
+        "a": "b"
+      },
+      [
+        false
+      ]
+    ]
+  },
+  {
+    "name": "filter, deep equality, arrays",
+    "selector": "$[?@.a==@.b]",
+    "document": [
+      {
+        "a": false,
+        "b": [
+          1,
+          2
+        ]
+      },
+      {
+        "a": [
+          [
+            1,
+            [
+              2
+            ]
+          ]
+        ],
+        "b": [
+          [
+            1,
+            [
+              2
+            ]
+          ]
+        ]
+      },
+      {
+        "a": [
+          [
+            1,
+            [
+              2
+            ]
+          ]
+        ],
+        "b": [
+          [
+            [
+              2
+            ],
+            1
+          ]
+        ]
+      },
+      {
+        "a": [
+          [
+            1,
+            [
+              2
+            ]
+          ]
+        ],
+        "b": [
+          [
+            1,
+            2
+          ]
+        ]
+      }
+    ],
+    "result": [
+      {
+        "a": [
+          [
+            1,
+            [
+              2
+            ]
+          ]
+        ],
+        "b": [
+          [
+            1,
+            [
+              2
+            ]
+          ]
+        ]
+      }
+    ]
+  },
+  {
+    "name": "filter, deep equality, objects",
+    "selector": "$[?@.a==@.b]",
+    "document": [
+      {
+        "a": false,
+        "b": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        }
+      },
+      {
+        "a": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        },
+        "b": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        }
+      },
+      {
+        "a": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        },
+        "b": {
+          "y": {
+            "z": 1
+          },
+          "x": 1
+        }
+      },
+      {
+        "a": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        },
+        "b": {
+          "x": 1
+        }
+      },
+      {
+        "a": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        },
+        "b": {
+          "x": 1,
+          "y": {
+            "z": 2
+          }
+        }
+      }
+    ],
+    "result": [
+      {
+        "a": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        },
+        "b": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        }
+      },
+      {
+        "a": {
+          "x": 1,
+          "y": {
+            "z": 1
+          }
+        },
+        "b": {
+          "y": {
+            "z": 1
+          },
+          "x": 1
+        }
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals string, single quotes",
+    "selector": "$[?@.a!='b']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals numeric string, single quotes",
+    "selector": "$[?@.a!='1']",
+    "document": [
+      {
+        "a": "1",
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals string, single quotes, different type",
+    "selector": "$[?@.a!='b']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals string, double quotes",
+    "selector": "$[?@.a!=\"b\"]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals numeric string, double quotes",
+    "selector": "$[?@.a!=\"1\"]",
+    "document": [
+      {
+        "a": "1",
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals string, double quotes, different types",
+    "selector": "$[?@.a!=\"b\"]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals number",
+    "selector": "$[?@.a!=1]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals number, different types",
+    "selector": "$[?@.a!=1]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals null",
+    "selector": "$[?@.a!=null]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals null, absent from data",
+    "selector": "$[?@.a!=null]",
+    "document": [
+      {
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals true",
+    "selector": "$[?@.a!=true]",
+    "document": [
+      {
+        "a": true,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not-equals false",
+    "selector": "$[?@.a!=false]",
+    "document": [
+      {
+        "a": false,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than string, single quotes",
+    "selector": "$[?@.a<'c']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than string, double quotes",
+    "selector": "$[?@.a<\"c\"]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than number",
+    "selector": "$[?@.a<10]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 10,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": 20,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than null",
+    "selector": "$[?@.a<null]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, less than true",
+    "selector": "$[?@.a<true]",
+    "document": [
+      {
+        "a": true,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, less than false",
+    "selector": "$[?@.a<false]",
+    "document": [
+      {
+        "a": false,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, less than or equal to string, single quotes",
+    "selector": "$[?@.a<='c']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than or equal to string, double quotes",
+    "selector": "$[?@.a<=\"c\"]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than or equal to number",
+    "selector": "$[?@.a<=10]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 10,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": 20,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 10,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than or equal to null",
+    "selector": "$[?@.a<=null]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": null,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than or equal to true",
+    "selector": "$[?@.a<=true]",
+    "document": [
+      {
+        "a": true,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": true,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, less than or equal to false",
+    "selector": "$[?@.a<=false]",
+    "document": [
+      {
+        "a": false,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": false,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than string, single quotes",
+    "selector": "$[?@.a>'c']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than string, double quotes",
+    "selector": "$[?@.a>\"c\"]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than number",
+    "selector": "$[?@.a>10]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 10,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": 20,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 20,
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than null",
+    "selector": "$[?@.a>null]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, greater than true",
+    "selector": "$[?@.a>true]",
+    "document": [
+      {
+        "a": true,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, greater than false",
+    "selector": "$[?@.a>false]",
+    "document": [
+      {
+        "a": false,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, greater than or equal to string, single quotes",
+    "selector": "$[?@.a>='c']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than or equal to string, double quotes",
+    "selector": "$[?@.a>=\"c\"]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than or equal to number",
+    "selector": "$[?@.a>=10]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 10,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": 20,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 10,
+        "d": "e"
+      },
+      {
+        "a": 20,
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than or equal to null",
+    "selector": "$[?@.a>=null]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": null,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than or equal to true",
+    "selector": "$[?@.a>=true]",
+    "document": [
+      {
+        "a": true,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": true,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, greater than or equal to false",
+    "selector": "$[?@.a>=false]",
+    "document": [
+      {
+        "a": false,
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": false,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, exists and not-equals null, absent from data",
+    "selector": "$[?@.a&&@.a!=null]",
+    "document": [
+      {
+        "d": "e"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, exists and exists, data false",
+    "selector": "$[?@.a&&@.b]",
+    "document": [
+      {
+        "a": false,
+        "b": false
+      },
+      {
+        "b": false
+      },
+      {
+        "c": false
+      }
+    ],
+    "result": [
+      {
+        "a": false,
+        "b": false
+      }
+    ]
+  },
+  {
+    "name": "filter, exists or exists, data false",
+    "selector": "$[?@.a||@.b]",
+    "document": [
+      {
+        "a": false,
+        "b": false
+      },
+      {
+        "b": false
+      },
+      {
+        "c": false
+      }
+    ],
+    "result": [
+      {
+        "a": false,
+        "b": false
+      },
+      {
+        "b": false
+      }
+    ]
+  },
+  {
+    "name": "filter, and",
+    "selector": "$[?@.a>0&&@.a<10]",
+    "document": [
+      {
+        "a": -10,
+        "d": "e"
+      },
+      {
+        "a": 5,
+        "d": "f"
+      },
+      {
+        "a": 20,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": 5,
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, or",
+    "selector": "$[?@.a=='b'||@.a=='d']",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "f"
+      },
+      {
+        "a": "c",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not expression",
+    "selector": "$[?!(@.a=='b')]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not exists",
+    "selector": "$[?!@.a]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, not exists, data null",
+    "selector": "$[?!@.a]",
+    "document": [
+      {
+        "a": null,
+        "d": "e"
+      },
+      {
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, non-singular existence, wildcard",
+    "selector": "$[?@.*]",
+    "document": [
+      1,
+      [],
+      [
+        2
+      ],
+      {},
+      {
+        "a": 3
+      }
+    ],
+    "result": [
+      [
+        2
+      ],
+      {
+        "a": 3
+      }
+    ]
+  },
+  {
+    "name": "filter, non-singular existence, multiple",
+    "selector": "$[?@[0, 0, 'a']]",
+    "document": [
+      1,
+      [],
+      [
+        2
+      ],
+      [
+        2,
+        3
+      ],
+      {
+        "a": 3
+      },
+      {
+        "b": 4
+      },
+      {
+        "a": 3,
+        "b": 4
+      }
+    ],
+    "result": [
+      [
+        2
+      ],
+      [
+        2,
+        3
+      ],
+      {
+        "a": 3
+      },
+      {
+        "a": 3,
+        "b": 4
+      }
+    ]
+  },
+  {
+    "name": "filter, non-singular existence, slice",
+    "selector": "$[?@[0:2]]",
+    "document": [
+      1,
+      [],
+      [
+        2
+      ],
+      [
+        2,
+        3,
+        4
+      ],
+      {},
+      {
+        "a": 3
+      }
+    ],
+    "result": [
+      [
+        2
+      ],
+      [
+        2,
+        3,
+        4
+      ]
+    ]
+  },
+  {
+    "name": "filter, non-singular existence, negated",
+    "selector": "$[?!@.*]",
+    "document": [
+      1,
+      [],
+      [
+        2
+      ],
+      {},
+      {
+        "a": 3
+      }
+    ],
+    "result": [
+      1,
+      [],
+      {}
+    ]
+  },
+  {
+    "name": "filter, non-singular query in comparison, slice",
+    "selector": "$[?@[0:0]==0]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, non-singular query in comparison, all children",
+    "selector": "$[?@[*]==0]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, non-singular query in comparison, descendants",
+    "selector": "$[?@..a==0]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, non-singular query in comparison, combined",
+    "selector": "$[?@.a[*].a==0]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, nested",
+    "selector": "$[?@[?@>1]]",
+    "document": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1,
+        2
+      ],
+      [
+        42
+      ]
+    ],
+    "result": [
+      [
+        0,
+        1,
+        2
+      ],
+      [
+        42
+      ]
+    ]
+  },
+  {
+    "name": "filter, name segment on primitive, selects nothing",
+    "selector": "$[?@.a == 1]",
+    "document": {
+      "a": 1
+    },
+    "result": []
+  },
+  {
+    "name": "filter, name segment on array, selects nothing",
+    "selector": "$[?@['0'] == 5]",
+    "document": [
+      [
+        5,
+        6
+      ]
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, index segment on object, selects nothing",
+    "selector": "$[?@[0] == 5]",
+    "document": [
+      {
+        "0": 5
+      }
+    ],
+    "result": []
+  },
+  {
+    "name": "filter, relative non-singular query, index, equal",
+    "selector": "$[?(@[0, 0]==42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, index, not equal",
+    "selector": "$[?(@[0, 0]!=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, index, less-or-equal",
+    "selector": "$[?(@[0, 0]<=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, name, equal",
+    "selector": "$[?(@['a', 'a']==42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, name, not equal",
+    "selector": "$[?(@['a', 'a']!=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, name, less-or-equal",
+    "selector": "$[?(@['a', 'a']<=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, combined, equal",
+    "selector": "$[?(@[0, '0']==42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, combined, not equal",
+    "selector": "$[?(@[0, '0']!=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, combined, less-or-equal",
+    "selector": "$[?(@[0, '0']<=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, relative non-singular query, wildcard, equal",
+    "selector": "$[?(@.*==42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, relative non-singular query, wildcard, not equal",
+    "selector": "$[?(@.*!=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, relative non-singular query, wildcard, less-or-equal",
+    "selector": "$[?(@.*<=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, relative non-singular query, slice, equal",
+    "selector": "$[?(@[0:0]==42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, relative non-singular query, slice, not equal",
+    "selector": "$[?(@[0:0]!=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, relative non-singular query, slice, less-or-equal",
+    "selector": "$[?(@[0:0]<=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, absolute non-singular query, index, equal",
+    "selector": "$[?($[0, 0]==42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, index, not equal",
+    "selector": "$[?($[0, 0]!=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, index, less-or-equal",
+    "selector": "$[?($[0, 0]<=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, name, equal",
+    "selector": "$[?($['a', 'a']==42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, name, not equal",
+    "selector": "$[?($['a', 'a']!=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, name, less-or-equal",
+    "selector": "$[?($['a', 'a']<=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, combined, equal",
+    "selector": "$[?($[0, '0']==42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, combined, not equal",
+    "selector": "$[?($[0, '0']!=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, combined, less-or-equal",
+    "selector": "$[?($[0, '0']<=42)]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, absolute non-singular query, wildcard, equal",
+    "selector": "$[?($.*==42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, absolute non-singular query, wildcard, not equal",
+    "selector": "$[?($.*!=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, absolute non-singular query, wildcard, less-or-equal",
+    "selector": "$[?($.*<=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, absolute non-singular query, slice, equal",
+    "selector": "$[?($[0:0]==42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, absolute non-singular query, slice, not equal",
+    "selector": "$[?($[0:0]!=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, absolute non-singular query, slice, less-or-equal",
+    "selector": "$[?($[0:0]<=42)]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, multiple selectors",
+    "selector": "$[?@.a,?@.b]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, multiple selectors, comparison",
+    "selector": "$[?@.a=='b',?@.b=='x']",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, multiple selectors, overlapping",
+    "selector": "$[?@.a,?@.d]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, multiple selectors, filter and index",
+    "selector": "$[?@.a,1]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, multiple selectors, filter and wildcard",
+    "selector": "$[?@.a,*]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ]
+  },
+  {
+    "name": "filter, multiple selectors, filter and slice",
+    "selector": "$[?@.a,1:]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      },
+      {
+        "g": "h"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      },
+      {
+        "g": "h"
+      }
+    ]
+  },
+  {
+    "name": "filter, multiple selectors, comparison filter, index and slice",
+    "selector": "$[1, ?@.a=='b', 1:]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "b": "c",
+        "d": "f"
+      },
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, equals number, zero and negative zero",
+    "selector": "$[?@.a==0]",
+    "document": [
+      {
+        "a": 0,
+        "d": "e"
+      },
+      {
+        "a": 0.1,
+        "d": "f"
+      },
+      {
+        "a": "0",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 0,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, negative zero and zero",
+    "selector": "$[?@.a==-0]",
+    "document": [
+      {
+        "a": 0,
+        "d": "e"
+      },
+      {
+        "a": 0.1,
+        "d": "f"
+      },
+      {
+        "a": "0",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 0,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, with and without decimal fraction",
+    "selector": "$[?@.a==1.0]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, exponent",
+    "selector": "$[?@.a==1e2]",
+    "document": [
+      {
+        "a": 100,
+        "d": "e"
+      },
+      {
+        "a": 100.1,
+        "d": "f"
+      },
+      {
+        "a": "100",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 100,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, exponent upper e",
+    "selector": "$[?@.a==1E2]",
+    "document": [
+      {
+        "a": 100,
+        "d": "e"
+      },
+      {
+        "a": 100.1,
+        "d": "f"
+      },
+      {
+        "a": "100",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 100,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, positive exponent",
+    "selector": "$[?@.a==1e+2]",
+    "document": [
+      {
+        "a": 100,
+        "d": "e"
+      },
+      {
+        "a": 100.1,
+        "d": "f"
+      },
+      {
+        "a": "100",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 100,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, negative exponent",
+    "selector": "$[?@.a==1e-2]",
+    "document": [
+      {
+        "a": 0.01,
+        "d": "e"
+      },
+      {
+        "a": 0.02,
+        "d": "f"
+      },
+      {
+        "a": "0.01",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 0.01,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, exponent 0",
+    "selector": "$[?@.a==1e0]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, exponent -0",
+    "selector": "$[?@.a==1e-0]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, exponent +0",
+    "selector": "$[?@.a==1e+0]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, exponent leading -0",
+    "selector": "$[?@.a==1e-02]",
+    "document": [
+      {
+        "a": 0.01,
+        "d": "e"
+      },
+      {
+        "a": 0.02,
+        "d": "f"
+      },
+      {
+        "a": "0.01",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 0.01,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, exponent +00",
+    "selector": "$[?@.a==1e+00]",
+    "document": [
+      {
+        "a": 1,
+        "d": "e"
+      },
+      {
+        "a": 2,
+        "d": "f"
+      },
+      {
+        "a": "1",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, decimal fraction",
+    "selector": "$[?@.a==1.1]",
+    "document": [
+      {
+        "a": 1.1,
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      },
+      {
+        "a": "1.1",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 1.1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, decimal fraction, trailing 0",
+    "selector": "$[?@.a==1.10]",
+    "document": [
+      {
+        "a": 1.1,
+        "d": "e"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      },
+      {
+        "a": "1.1",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 1.1,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, decimal fraction, exponent",
+    "selector": "$[?@.a==1.1e2]",
+    "document": [
+      {
+        "a": 110,
+        "d": "e"
+      },
+      {
+        "a": 110.1,
+        "d": "f"
+      },
+      {
+        "a": "110",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 110,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, decimal fraction, positive exponent",
+    "selector": "$[?@.a==1.1e+2]",
+    "document": [
+      {
+        "a": 110,
+        "d": "e"
+      },
+      {
+        "a": 110.1,
+        "d": "f"
+      },
+      {
+        "a": "110",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 110,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, decimal fraction, negative exponent",
+    "selector": "$[?@.a==1.1e-2]",
+    "document": [
+      {
+        "a": 0.011,
+        "d": "e"
+      },
+      {
+        "a": 0.012,
+        "d": "f"
+      },
+      {
+        "a": "0.011",
+        "d": "g"
+      }
+    ],
+    "result": [
+      {
+        "a": 0.011,
+        "d": "e"
+      }
+    ]
+  },
+  {
+    "name": "filter, equals number, invalid plus",
+    "selector": "$[?@.a==+1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid minus space",
+    "selector": "$[?@.a==- 1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid double minus",
+    "selector": "$[?@.a==--1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid no int digit",
+    "selector": "$[?@.a==.1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid minus no int digit",
+    "selector": "$[?@.a==-.1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid 00",
+    "selector": "$[?@.a==00]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid leading 0",
+    "selector": "$[?@.a==01]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid no fractional digit",
+    "selector": "$[?@.a==1.]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid middle minus",
+    "selector": "$[?@.a==1.-1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid no fractional digit e",
+    "selector": "$[?@.a==1.e1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid no e digit",
+    "selector": "$[?@.a==1e]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid no e digit minus",
+    "selector": "$[?@.a==1e-]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid double e",
+    "selector": "$[?@.a==1eE1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid e digit double minus",
+    "selector": "$[?@.a==1e--1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid e digit plus minus",
+    "selector": "$[?@.a==1e+-1]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid e decimal",
+    "selector": "$[?@.a==1e2.3]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals number, invalid multi e",
+    "selector": "$[?@.a==1e2e3]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, equals, special nothing",
+    "selector": "$.values[?length(@.a) == value($..c)]",
+    "document": {
+      "c": "cd",
+      "values": [
+        {
+          "a": "ab"
+        },
+        {
+          "c": "d"
+        },
+        {
+          "a": null
+        }
+      ]
+    },
+    "result": [
+      {
+        "c": "d"
+      },
+      {
+        "a": null
+      }
+    ]
+  },
+  {
+    "name": "filter, equals, empty node list and empty node list",
+    "selector": "$[?@.a == @.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "c": 3
+      }
+    ]
+  },
+  {
+    "name": "filter, equals, empty node list and special nothing",
+    "selector": "$[?@.a == length(@.b)]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, object data",
+    "selector": "$[?@<3]",
+    "document": {
+      "a": 1,
+      "b": 2,
+      "c": 3
+    },
+    "results": [
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        1
+      ]
+    ]
+  },
+  {
+    "name": "filter, and binds more tightly than or",
+    "selector": "$[?@.a || @.b && @.c]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2,
+        "c": 3
+      },
+      {
+        "c": 3
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2,
+        "c": 3
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, left to right evaluation",
+    "selector": "$[?@.a && @.b || @.c]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 1,
+        "c": 3
+      },
+      {
+        "b": 1,
+        "c": 3
+      },
+      {
+        "c": 3
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 1,
+        "c": 3
+      },
+      {
+        "b": 1,
+        "c": 3
+      },
+      {
+        "c": 3
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, group terms, left",
+    "selector": "$[?(@.a || @.b) && @.c]",
+    "document": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 1,
+        "c": 3
+      },
+      {
+        "b": 2,
+        "c": 3
+      },
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "c": 3
+      },
+      {
+        "b": 2,
+        "c": 3
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, group terms, right",
+    "selector": "$[?@.a && (@.b || @.c)]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 1,
+        "c": 2
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 2
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 1,
+        "c": 2
+      },
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, string literal, single quote in double quotes",
+    "selector": "$[?@ == \"quoted' literal\"]",
+    "document": [
+      "quoted' literal",
+      "a",
+      "quoted\\' literal"
+    ],
+    "result": [
+      "quoted' literal"
+    ]
+  },
+  {
+    "name": "filter, string literal, double quote in single quotes",
+    "selector": "$[?@ == 'quoted\" literal']",
+    "document": [
+      "quoted\" literal",
+      "a",
+      "quoted\\\" literal",
+      "'quoted\" literal'"
+    ],
+    "result": [
+      "quoted\" literal"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, string literal, escaped single quote in single quotes",
+    "selector": "$[?@ == 'quoted\\' literal']",
+    "document": [
+      "quoted' literal",
+      "a",
+      "quoted\\' literal",
+      "'quoted\" literal'"
+    ],
+    "result": [
+      "quoted' literal"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, string literal, escaped double quote in double quotes",
+    "selector": "$[?@ == \"quoted\\\" literal\"]",
+    "document": [
+      "quoted\" literal",
+      "a",
+      "quoted\\\" literal",
+      "'quoted\" literal'"
+    ],
+    "result": [
+      "quoted\" literal"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, literal true must be compared",
+    "selector": "$[?true]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, literal false must be compared",
+    "selector": "$[?false]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, literal string must be compared",
+    "selector": "$[?'abc']",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, literal int must be compared",
+    "selector": "$[?2]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, literal float must be compared",
+    "selector": "$[?2.2]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, literal null must be compared",
+    "selector": "$[?null]",
+    "invalid_selector": true
+  },
+  {
+    "name": "filter, and, literals must be compared",
+    "selector": "$[?true && false]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, or, literals must be compared",
+    "selector": "$[?true || false]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, and, right hand literal must be compared",
+    "selector": "$[?true == false && false]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, or, right hand literal must be compared",
+    "selector": "$[?true == false || false]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, and, left hand literal must be compared",
+    "selector": "$[?false && true == false]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, or, left hand literal must be compared",
+    "selector": "$[?false || true == false]",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "filter, true, incorrectly capitalized",
+    "selector": "$[?@==True]",
+    "invalid_selector": true,
+    "tags": [
+      "case"
+    ]
+  },
+  {
+    "name": "filter, false, incorrectly capitalized",
+    "selector": "$[?@==False]",
+    "invalid_selector": true,
+    "tags": [
+      "case"
+    ]
+  },
+  {
+    "name": "filter, null, incorrectly capitalized",
+    "selector": "$[?@==Null]",
+    "invalid_selector": true,
+    "tags": [
+      "case"
+    ]
+  },
+  {
+    "name": "index selector, first element",
+    "selector": "$[0]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [
+      "first"
+    ],
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, second element",
+    "selector": "$[1]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [
+      "second"
+    ],
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, out of bound",
+    "selector": "$[2]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [],
+    "tags": [
+      "boundary",
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, min exact index",
+    "selector": "$[-9007199254740991]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [],
+    "tags": [
+      "boundary",
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, max exact index",
+    "selector": "$[9007199254740991]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [],
+    "tags": [
+      "boundary",
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, min exact index - 1",
+    "selector": "$[-9007199254740992]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, max exact index + 1",
+    "selector": "$[9007199254740992]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, overflowing index",
+    "selector": "$[231584178474632390847141970017375815706539969331281128078915168015826259279872]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, not actually an index, overflowing index leads into general text",
+    "selector": "$[231584178474632390847141970017375815706539969331281128078915168SomeRandomText]",
+    "invalid_selector": true,
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, negative",
+    "selector": "$[-1]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [
+      "second"
+    ],
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, more negative",
+    "selector": "$[-2]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [
+      "first"
+    ],
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, negative out of bound",
+    "selector": "$[-3]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": [],
+    "tags": [
+      "boundary",
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, on object",
+    "selector": "$[0]",
+    "document": {
+      "foo": 1
+    },
+    "result": [],
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, leading 0",
+    "selector": "$[01]",
+    "invalid_selector": true,
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, decimal",
+    "selector": "$[1.0]",
+    "invalid_selector": true,
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, plus",
+    "selector": "$[+1]",
+    "invalid_selector": true,
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, minus space",
+    "selector": "$[- 1]",
+    "invalid_selector": true,
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "index selector, -0",
+    "selector": "$[-0]",
+    "invalid_selector": true,
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "index selector, leading -0",
+    "selector": "$[-01]",
+    "invalid_selector": true,
+    "tags": [
+      "index"
+    ]
+  },
+  {
+    "name": "name selector, double quotes",
+    "selector": "$[\"a\"]",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, absent data",
+    "selector": "$[\"c\"]",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "result": []
+  },
+  {
+    "name": "name selector, double quotes, array data",
+    "selector": "$[\"a\"]",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": []
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0000",
+    "selector": "$[\"\u0000\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0001",
+    "selector": "$[\"\u0001\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0002",
+    "selector": "$[\"\u0002\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0003",
+    "selector": "$[\"\u0003\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0004",
+    "selector": "$[\"\u0004\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0005",
+    "selector": "$[\"\u0005\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0006",
+    "selector": "$[\"\u0006\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0007",
+    "selector": "$[\"\u0007\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0008",
+    "selector": "$[\"\b\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0009",
+    "selector": "$[\"\t\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+000A",
+    "selector": "$[\"\n\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+000B",
+    "selector": "$[\"\u000b\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+000C",
+    "selector": "$[\"\f\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+000D",
+    "selector": "$[\"\r\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+000E",
+    "selector": "$[\"\u000e\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+000F",
+    "selector": "$[\"\u000f\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0010",
+    "selector": "$[\"\u0010\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0011",
+    "selector": "$[\"\u0011\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0012",
+    "selector": "$[\"\u0012\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0013",
+    "selector": "$[\"\u0013\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0014",
+    "selector": "$[\"\u0014\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0015",
+    "selector": "$[\"\u0015\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0016",
+    "selector": "$[\"\u0016\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0017",
+    "selector": "$[\"\u0017\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0018",
+    "selector": "$[\"\u0018\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0019",
+    "selector": "$[\"\u0019\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+001A",
+    "selector": "$[\"\u001a\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+001B",
+    "selector": "$[\"\u001b\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+001C",
+    "selector": "$[\"\u001c\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+001D",
+    "selector": "$[\"\u001d\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+001E",
+    "selector": "$[\"\u001e\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+001F",
+    "selector": "$[\"\u001f\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+0020",
+    "selector": "$[\" \"]",
+    "document": {
+      " ": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, embedded U+007F",
+    "selector": "$[\"\u007f\"]",
+    "document": {
+      "\u007f": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, supplementary plane character",
+    "selector": "$[\"𝄞\"]",
+    "document": {
+      "𝄞": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped double quote",
+    "selector": "$[\"\\\"\"]",
+    "document": {
+      "\"": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped reverse solidus",
+    "selector": "$[\"\\\\\"]",
+    "document": {
+      "\\": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped solidus",
+    "selector": "$[\"\\/\"]",
+    "document": {
+      "/": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped backspace",
+    "selector": "$[\"\\b\"]",
+    "document": {
+      "\b": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped form feed",
+    "selector": "$[\"\\f\"]",
+    "document": {
+      "\f": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped line feed",
+    "selector": "$[\"\\n\"]",
+    "document": {
+      "\n": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped carriage return",
+    "selector": "$[\"\\r\"]",
+    "document": {
+      "\r": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped tab",
+    "selector": "$[\"\\t\"]",
+    "document": {
+      "\t": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped ☺, upper case hex",
+    "selector": "$[\"\\u263A\"]",
+    "document": {
+      "☺": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, escaped ☺, lower case hex",
+    "selector": "$[\"\\u263a\"]",
+    "document": {
+      "☺": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, surrogate pair 𝄞",
+    "selector": "$[\"\\uD834\\uDD1E\"]",
+    "document": {
+      "𝄞": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, surrogate pair 😀",
+    "selector": "$[\"\\uD83D\\uDE00\"]",
+    "document": {
+      "😀": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, before high surrogates",
+    "selector": "$[\"\\uD7FF\\uD7FF\"]",
+    "document": {
+      "퟿퟿": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, after low surrogates",
+    "selector": "$[\"\\uE000\\uE000\"]",
+    "document": {
+      "": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, invalid escaped single quote",
+    "selector": "$[\"\\'\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, embedded double quote",
+    "selector": "$[\"\"\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, incomplete escape",
+    "selector": "$[\"\\\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, escape at end of line",
+    "selector": "$[\"\\\n\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, question mark escape",
+    "selector": "$[\"\\?\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, bell escape",
+    "selector": "$[\"\\a\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, vertical tab escape",
+    "selector": "$[\"\\v\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, 0 escape",
+    "selector": "$[\"\\0\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, x escape",
+    "selector": "$[\"\\x12\"]",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, n escape",
+    "selector": "$[\"\\N{LATIN CAPITAL LETTER A}\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, unicode escape no hex",
+    "selector": "$[\"\\u\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, unicode escape too few hex",
+    "selector": "$[\"\\u123\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, unicode escape upper u",
+    "selector": "$[\"\\U1234\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, unicode escape upper u long",
+    "selector": "$[\"\\U0010FFFF\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, unicode escape plus",
+    "selector": "$[\"\\u+1234\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, unicode escape brackets",
+    "selector": "$[\"\\u{1234}\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, unicode escape brackets long",
+    "selector": "$[\"\\u{10ffff}\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, single high surrogate",
+    "selector": "$[\"\\uD800\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, single low surrogate",
+    "selector": "$[\"\\uDC00\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, high high surrogate",
+    "selector": "$[\"\\uD800\\uD800\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, low low surrogate",
+    "selector": "$[\"\\uDC00\\uDC00\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, surrogate non-surrogate",
+    "selector": "$[\"\\uD800\\u1234\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, non-surrogate surrogate",
+    "selector": "$[\"\\u1234\\uDC00\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, surrogate supplementary",
+    "selector": "$[\"\\uD800𝄞\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, supplementary surrogate",
+    "selector": "$[\"𝄞\\uDC00\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, double quotes, surrogate incomplete low",
+    "selector": "$[\"\\uD800\\uDC0\"]",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes",
+    "selector": "$['a']",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, absent data",
+    "selector": "$['c']",
+    "document": {
+      "a": "A",
+      "b": "B"
+    },
+    "result": []
+  },
+  {
+    "name": "name selector, single quotes, array data",
+    "selector": "$['a']",
+    "document": [
+      "first",
+      "second"
+    ],
+    "result": []
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0000",
+    "selector": "$['\u0000']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0001",
+    "selector": "$['\u0001']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0002",
+    "selector": "$['\u0002']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0003",
+    "selector": "$['\u0003']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0004",
+    "selector": "$['\u0004']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0005",
+    "selector": "$['\u0005']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0006",
+    "selector": "$['\u0006']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0007",
+    "selector": "$['\u0007']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0008",
+    "selector": "$['\b']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0009",
+    "selector": "$['\t']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+000A",
+    "selector": "$['\n']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+000B",
+    "selector": "$['\u000b']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+000C",
+    "selector": "$['\f']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+000D",
+    "selector": "$['\r']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+000E",
+    "selector": "$['\u000e']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+000F",
+    "selector": "$['\u000f']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0010",
+    "selector": "$['\u0010']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0011",
+    "selector": "$['\u0011']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0012",
+    "selector": "$['\u0012']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0013",
+    "selector": "$['\u0013']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0014",
+    "selector": "$['\u0014']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0015",
+    "selector": "$['\u0015']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0016",
+    "selector": "$['\u0016']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0017",
+    "selector": "$['\u0017']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0018",
+    "selector": "$['\u0018']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0019",
+    "selector": "$['\u0019']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+001A",
+    "selector": "$['\u001a']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+001B",
+    "selector": "$['\u001b']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+001C",
+    "selector": "$['\u001c']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+001D",
+    "selector": "$['\u001d']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+001E",
+    "selector": "$['\u001e']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+001F",
+    "selector": "$['\u001f']",
+    "invalid_selector": true,
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, embedded U+0020",
+    "selector": "$[' ']",
+    "document": {
+      " ": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped single quote",
+    "selector": "$['\\'']",
+    "document": {
+      "'": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped reverse solidus",
+    "selector": "$['\\\\']",
+    "document": {
+      "\\": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped solidus",
+    "selector": "$['\\/']",
+    "document": {
+      "/": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped backspace",
+    "selector": "$['\\b']",
+    "document": {
+      "\b": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped form feed",
+    "selector": "$['\\f']",
+    "document": {
+      "\f": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped line feed",
+    "selector": "$['\\n']",
+    "document": {
+      "\n": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped carriage return",
+    "selector": "$['\\r']",
+    "document": {
+      "\r": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped tab",
+    "selector": "$['\\t']",
+    "document": {
+      "\t": "A"
+    },
+    "result": [
+      "A"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped ☺, upper case hex",
+    "selector": "$['\\u263A']",
+    "document": {
+      "☺": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, escaped ☺, lower case hex",
+    "selector": "$['\\u263a']",
+    "document": {
+      "☺": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, surrogate pair 𝄞",
+    "selector": "$['\\uD834\\uDD1E']",
+    "document": {
+      "𝄞": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, surrogate pair 😀",
+    "selector": "$['\\uD83D\\uDE00']",
+    "document": {
+      "😀": "A"
+    },
+    "result": [
+      "A"
+    ],
+    "tags": [
+      "unicode"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, invalid escaped double quote",
+    "selector": "$['\\\"']",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, single quotes, embedded single quote",
+    "selector": "$[''']",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, single quotes, incomplete escape",
+    "selector": "$['\\']",
+    "invalid_selector": true
+  },
+  {
+    "name": "name selector, double quotes, empty",
+    "selector": "$[\"\"]",
+    "document": {
+      "a": "A",
+      "b": "B",
+      "": "C"
+    },
+    "result": [
+      "C"
+    ]
+  },
+  {
+    "name": "name selector, single quotes, empty",
+    "selector": "$['']",
+    "document": {
+      "a": "A",
+      "b": "B",
+      "": "C"
+    },
+    "result": [
+      "C"
+    ]
+  },
+  {
+    "name": "slice selector, slice selector",
+    "selector": "$[1:3]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1,
+      2
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, slice selector with step",
+    "selector": "$[1:6:2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1,
+      3,
+      5
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, slice selector with everything omitted, short form",
+    "selector": "$[:]",
+    "document": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "result": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, slice selector with everything omitted, long form",
+    "selector": "$[::]",
+    "document": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "result": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, slice selector with start omitted",
+    "selector": "$[:2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      0,
+      1
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, slice selector with start and end omitted",
+    "selector": "$[::2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      0,
+      2,
+      4,
+      6,
+      8
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative step with default start and end",
+    "selector": "$[::-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "result": [
+      3,
+      2,
+      1,
+      0
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative step with default start",
+    "selector": "$[:0:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "result": [
+      3,
+      2,
+      1
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative step with default end",
+    "selector": "$[2::-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "result": [
+      2,
+      1,
+      0
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, larger negative step",
+    "selector": "$[::-2]",
+    "document": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "result": [
+      3,
+      1
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative range with default step",
+    "selector": "$[-1:-3]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative range with negative step",
+    "selector": "$[-1:-3:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      9,
+      8
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative range with larger negative step",
+    "selector": "$[-1:-6:-2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      9,
+      7,
+      5
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, larger negative range with larger negative step",
+    "selector": "$[-1:-7:-2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      9,
+      7,
+      5
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative from, positive to",
+    "selector": "$[-5:7]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      5,
+      6
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative from",
+    "selector": "$[-2:]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      8,
+      9
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, positive from, negative to",
+    "selector": "$[1:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative from, positive to, negative step",
+    "selector": "$[-1:1:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      9,
+      8,
+      7,
+      6,
+      5,
+      4,
+      3,
+      2
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, positive from, negative to, negative step",
+    "selector": "$[7:-5:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      7,
+      6
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, too many colons",
+    "selector": "$[1:2:3:4]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, non-integer array index",
+    "selector": "$[1:2:a]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, zero step",
+    "selector": "$[1:2:0]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, empty range",
+    "selector": "$[2:2]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, slice selector with everything omitted with empty array",
+    "selector": "$[:]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, negative step with empty array",
+    "selector": "$[::-1]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, maximal range with positive step",
+    "selector": "$[0:10]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, maximal range with negative step",
+    "selector": "$[9:0:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      9,
+      8,
+      7,
+      6,
+      5,
+      4,
+      3,
+      2,
+      1
+    ],
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, excessively large to value",
+    "selector": "$[2:113667776004]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, excessively small from value",
+    "selector": "$[-113667776004:1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      0
+    ],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, excessively large from value with negative step",
+    "selector": "$[113667776004:0:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      9,
+      8,
+      7,
+      6,
+      5,
+      4,
+      3,
+      2,
+      1
+    ],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, excessively small to value with negative step",
+    "selector": "$[3:-113667776004:-1]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      3,
+      2,
+      1,
+      0
+    ],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, excessively large step",
+    "selector": "$[1:10:113667776004]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      1
+    ],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, excessively small step",
+    "selector": "$[-1:-10:-113667776004]",
+    "document": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "result": [
+      9
+    ],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, min exact",
+    "selector": "$[-9007199254740991::]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, max exact",
+    "selector": "$[9007199254740991::]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, min exact - 1",
+    "selector": "$[-9007199254740992::]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, max exact + 1",
+    "selector": "$[9007199254740992::]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, min exact",
+    "selector": "$[:-9007199254740991:]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, max exact",
+    "selector": "$[:9007199254740991:]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, min exact - 1",
+    "selector": "$[:-9007199254740992:]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, max exact + 1",
+    "selector": "$[:9007199254740992:]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, min exact",
+    "selector": "$[::-9007199254740991]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, max exact",
+    "selector": "$[::9007199254740991]",
+    "document": [],
+    "result": [],
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, min exact - 1",
+    "selector": "$[::-9007199254740992]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, max exact + 1",
+    "selector": "$[::9007199254740992]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, overflowing to value",
+    "selector": "$[2:231584178474632390847141970017375815706539969331281128078915168015826259279872]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, underflowing from value",
+    "selector": "$[-231584178474632390847141970017375815706539969331281128078915168015826259279872:1]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, overflowing from value with negative step",
+    "selector": "$[231584178474632390847141970017375815706539969331281128078915168015826259279872:0:-1]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, underflowing to value with negative step",
+    "selector": "$[3:-231584178474632390847141970017375815706539969331281128078915168015826259279872:-1]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, overflowing step",
+    "selector": "$[1:10:231584178474632390847141970017375815706539969331281128078915168015826259279872]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, underflowing step",
+    "selector": "$[-1:-10:-231584178474632390847141970017375815706539969331281128078915168015826259279872]",
+    "invalid_selector": true,
+    "tags": [
+      "boundary",
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, leading 0",
+    "selector": "$[01::]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, decimal",
+    "selector": "$[1.0::]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, plus",
+    "selector": "$[+1::]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, minus space",
+    "selector": "$[- 1::]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, -0",
+    "selector": "$[-0::]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, start, leading -0",
+    "selector": "$[-01::]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, leading 0",
+    "selector": "$[:01:]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, decimal",
+    "selector": "$[:1.0:]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, plus",
+    "selector": "$[:+1:]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, minus space",
+    "selector": "$[:- 1:]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, -0",
+    "selector": "$[:-0:]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, end, leading -0",
+    "selector": "$[:-01:]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, leading 0",
+    "selector": "$[::01]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, decimal",
+    "selector": "$[::1.0]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, plus",
+    "selector": "$[::+1]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, minus space",
+    "selector": "$[::- 1]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, -0",
+    "selector": "$[::-0]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "slice selector, step, leading -0",
+    "selector": "$[::-01]",
+    "invalid_selector": true,
+    "tags": [
+      "slice"
+    ]
+  },
+  {
+    "name": "functions, count, count function",
+    "selector": "$[?count(@..*)>2]",
+    "document": [
+      {
+        "a": [
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "a": [
+          1
+        ],
+        "d": "f"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": [
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "a": [
+          1
+        ],
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, single-node arg",
+    "selector": "$[?count(@.a)>1]",
+    "document": [
+      {
+        "a": [
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "a": [
+          1
+        ],
+        "d": "f"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, multiple-selector arg",
+    "selector": "$[?count(@['a','d'])>1]",
+    "document": [
+      {
+        "a": [
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "a": [
+          1
+        ],
+        "d": "f"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": [
+          1
+        ],
+        "d": "f"
+      },
+      {
+        "a": 1,
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, non-query arg, number",
+    "selector": "$[?count(1)>2]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, non-query arg, string",
+    "selector": "$[?count('string')>2]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, non-query arg, true",
+    "selector": "$[?count(true)>2]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, non-query arg, false",
+    "selector": "$[?count(false)>2]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, non-query arg, null",
+    "selector": "$[?count(null)>2]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, result must be compared",
+    "selector": "$[?count(@..*)]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, no params",
+    "selector": "$[?count()==1]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, count, too many params",
+    "selector": "$[?count(@.a,@.b)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function"
+    ]
+  },
+  {
+    "name": "functions, length, string data",
+    "selector": "$[?length(@.a)>=2]",
+    "document": [
+      {
+        "a": "ab"
+      },
+      {
+        "a": "d"
+      }
+    ],
+    "result": [
+      {
+        "a": "ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, string data, unicode",
+    "selector": "$[?length(@)==2]",
+    "document": [
+      "☺",
+      "☺☺",
+      "☺☺☺",
+      "ж",
+      "жж",
+      "жжж",
+      "磨",
+      "阿美",
+      "形声字"
+    ],
+    "result": [
+      "☺☺",
+      "жж",
+      "阿美"
+    ],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, array data",
+    "selector": "$[?length(@.a)>=2]",
+    "document": [
+      {
+        "a": [
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "a": [
+          1
+        ]
+      }
+    ],
+    "result": [
+      {
+        "a": [
+          1,
+          2,
+          3
+        ]
+      }
+    ],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, missing data",
+    "selector": "$[?length(@.a)>=2]",
+    "document": [
+      {
+        "d": "f"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, number arg",
+    "selector": "$[?length(1)>=2]",
+    "document": [
+      {
+        "d": "f"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, true arg",
+    "selector": "$[?length(true)>=2]",
+    "document": [
+      {
+        "d": "f"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, false arg",
+    "selector": "$[?length(false)>=2]",
+    "document": [
+      {
+        "d": "f"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, null arg",
+    "selector": "$[?length(null)>=2]",
+    "document": [
+      {
+        "d": "f"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, result must be compared",
+    "selector": "$[?length(@.a)]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, no params",
+    "selector": "$[?length()==1]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, too many params",
+    "selector": "$[?length(@.a,@.b)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, non-singular query arg",
+    "selector": "$[?length(@.*)<3]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, arg is a function expression",
+    "selector": "$.values[?length(@.a)==length(value($..c))]",
+    "document": {
+      "c": "cd",
+      "values": [
+        {
+          "a": "ab"
+        },
+        {
+          "a": "d"
+        }
+      ]
+    },
+    "result": [
+      {
+        "a": "ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, length, arg is special nothing",
+    "selector": "$[?length(value(@.a))>0]",
+    "document": [
+      {
+        "a": "ab"
+      },
+      {
+        "c": "d"
+      },
+      {
+        "a": null
+      }
+    ],
+    "result": [
+      {
+        "a": "ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "length"
+    ]
+  },
+  {
+    "name": "functions, match, found match",
+    "selector": "$[?match(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "ab"
+      }
+    ],
+    "result": [
+      {
+        "a": "ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, double quotes",
+    "selector": "$[?match(@.a, \"a.*\")]",
+    "document": [
+      {
+        "a": "ab"
+      }
+    ],
+    "result": [
+      {
+        "a": "ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, regex from the document",
+    "selector": "$.values[?match(@, $.regex)]",
+    "document": {
+      "regex": "b.?b",
+      "values": [
+        "abc",
+        "bcd",
+        "bab",
+        "bba",
+        "bbab",
+        "b",
+        true,
+        [],
+        {}
+      ]
+    },
+    "result": [
+      "bab"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, don't select match",
+    "selector": "$[?!match(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "ab"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, not a match",
+    "selector": "$[?match(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, select non-match",
+    "selector": "$[?!match(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [
+      {
+        "a": "bc"
+      }
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, non-string first arg",
+    "selector": "$[?match(1, 'a.*')]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, non-string second arg",
+    "selector": "$[?match(@.a, 1)]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, filter, match function, unicode char class, uppercase",
+    "selector": "$[?match(@, '\\\\p{Lu}')]",
+    "document": [
+      "ж",
+      "Ж",
+      "1",
+      "жЖ",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      "Ж"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, filter, match function, unicode char class negated, uppercase",
+    "selector": "$[?match(@, '\\\\P{Lu}')]",
+    "document": [
+      "ж",
+      "Ж",
+      "1",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      "ж",
+      "1"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, filter, match function, unicode, surrogate pair",
+    "selector": "$[?match(@, 'a.b')]",
+    "document": [
+      "a𐄁b",
+      "ab",
+      "1",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      "a𐄁b"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, dot matcher on \\u2028",
+    "selector": "$[?match(@, '.')]",
+    "document": [
+      " ",
+      "\r",
+      "\n",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      " "
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, dot matcher on \\u2029",
+    "selector": "$[?match(@, '.')]",
+    "document": [
+      " ",
+      "\r",
+      "\n",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      " "
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, result cannot be compared",
+    "selector": "$[?match(@.a, 'a.*')==true]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, too few params",
+    "selector": "$[?match(@.a)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, too many params",
+    "selector": "$[?match(@.a,@.b,@.c)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, arg is a function expression",
+    "selector": "$.values[?match(@.a, value($..['regex']))]",
+    "document": {
+      "regex": "a.*",
+      "values": [
+        {
+          "a": "ab"
+        },
+        {
+          "a": "ba"
+        }
+      ]
+    },
+    "result": [
+      {
+        "a": "ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, dot in character class",
+    "selector": "$[?match(@, 'a[.b]c')]",
+    "document": [
+      "abc",
+      "a.c",
+      "axc"
+    ],
+    "result": [
+      "abc",
+      "a.c"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, escaped dot",
+    "selector": "$[?match(@, 'a\\\\.c')]",
+    "document": [
+      "abc",
+      "a.c",
+      "axc"
+    ],
+    "result": [
+      "a.c"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, escaped backslash before dot",
+    "selector": "$[?match(@, 'a\\\\\\\\.c')]",
+    "document": [
+      "abc",
+      "a.c",
+      "axc",
+      "a\\ c"
+    ],
+    "result": [
+      "a\\ c"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, escaped left square bracket",
+    "selector": "$[?match(@, 'a\\\\[.c')]",
+    "document": [
+      "abc",
+      "a.c",
+      "a[ c"
+    ],
+    "result": [
+      "a[ c"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, escaped right square bracket",
+    "selector": "$[?match(@, 'a[\\\\].]c')]",
+    "document": [
+      "abc",
+      "a.c",
+      "a c",
+      "a]c"
+    ],
+    "result": [
+      "a.c",
+      "a]c"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, explicit caret",
+    "selector": "$[?match(@, '^ab.*')]",
+    "document": [
+      "abc",
+      "axc",
+      "ab",
+      "xab"
+    ],
+    "result": [
+      "abc",
+      "ab"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, match, explicit dollar",
+    "selector": "$[?match(@, '.*bc$')]",
+    "document": [
+      "abc",
+      "axc",
+      "ab",
+      "abcx"
+    ],
+    "result": [
+      "abc"
+    ],
+    "tags": [
+      "function",
+      "match"
+    ]
+  },
+  {
+    "name": "functions, search, at the end",
+    "selector": "$[?search(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "the end is ab"
+      }
+    ],
+    "result": [
+      {
+        "a": "the end is ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, double quotes",
+    "selector": "$[?search(@.a, \"a.*\")]",
+    "document": [
+      {
+        "a": "the end is ab"
+      }
+    ],
+    "result": [
+      {
+        "a": "the end is ab"
+      }
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, at the start",
+    "selector": "$[?search(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "ab is at the start"
+      }
+    ],
+    "result": [
+      {
+        "a": "ab is at the start"
+      }
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, in the middle",
+    "selector": "$[?search(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "contains two matches"
+      }
+    ],
+    "result": [
+      {
+        "a": "contains two matches"
+      }
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, regex from the document",
+    "selector": "$.values[?search(@, $.regex)]",
+    "document": {
+      "regex": "b.?b",
+      "values": [
+        "abc",
+        "bcd",
+        "bab",
+        "bba",
+        "bbab",
+        "b",
+        true,
+        [],
+        {}
+      ]
+    },
+    "result": [
+      "bab",
+      "bba",
+      "bbab"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, don't select match",
+    "selector": "$[?!search(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "contains two matches"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, not a match",
+    "selector": "$[?search(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, select non-match",
+    "selector": "$[?!search(@.a, 'a.*')]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [
+      {
+        "a": "bc"
+      }
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, non-string first arg",
+    "selector": "$[?search(1, 'a.*')]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, non-string second arg",
+    "selector": "$[?search(@.a, 1)]",
+    "document": [
+      {
+        "a": "bc"
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, filter, search function, unicode char class, uppercase",
+    "selector": "$[?search(@, '\\\\p{Lu}')]",
+    "document": [
+      "ж",
+      "Ж",
+      "1",
+      "жЖ",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      "Ж",
+      "жЖ"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, filter, search function, unicode char class negated, uppercase",
+    "selector": "$[?search(@, '\\\\P{Lu}')]",
+    "document": [
+      "ж",
+      "Ж",
+      "1",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      "ж",
+      "1"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, filter, search function, unicode, surrogate pair",
+    "selector": "$[?search(@, 'a.b')]",
+    "document": [
+      "a𐄁bc",
+      "abc",
+      "1",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      "a𐄁bc"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, dot matcher on \\u2028",
+    "selector": "$[?search(@, '.')]",
+    "document": [
+      " ",
+      "\r \n",
+      "\r",
+      "\n",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      " ",
+      "\r \n"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, dot matcher on \\u2029",
+    "selector": "$[?search(@, '.')]",
+    "document": [
+      " ",
+      "\r \n",
+      "\r",
+      "\n",
+      true,
+      [],
+      {}
+    ],
+    "result": [
+      " ",
+      "\r \n"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, result cannot be compared",
+    "selector": "$[?search(@.a, 'a.*')==true]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, too few params",
+    "selector": "$[?search(@.a)]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, too many params",
+    "selector": "$[?search(@.a,@.b,@.c)]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, arg is a function expression",
+    "selector": "$.values[?search(@, value($..['regex']))]",
+    "document": {
+      "regex": "b.?b",
+      "values": [
+        "abc",
+        "bcd",
+        "bab",
+        "bba",
+        "bbab",
+        "b",
+        true,
+        [],
+        {}
+      ]
+    },
+    "result": [
+      "bab",
+      "bba",
+      "bbab"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, dot in character class",
+    "selector": "$[?search(@, 'a[.b]c')]",
+    "document": [
+      "x abc y",
+      "x a.c y",
+      "x axc y"
+    ],
+    "result": [
+      "x abc y",
+      "x a.c y"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, escaped dot",
+    "selector": "$[?search(@, 'a\\\\.c')]",
+    "document": [
+      "x abc y",
+      "x a.c y",
+      "x axc y"
+    ],
+    "result": [
+      "x a.c y"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, escaped backslash before dot",
+    "selector": "$[?search(@, 'a\\\\\\\\.c')]",
+    "document": [
+      "x abc y",
+      "x a.c y",
+      "x axc y",
+      "x a\\ c y"
+    ],
+    "result": [
+      "x a\\ c y"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, escaped left square bracket",
+    "selector": "$[?search(@, 'a\\\\[.c')]",
+    "document": [
+      "x abc y",
+      "x a.c y",
+      "x a[ c y"
+    ],
+    "result": [
+      "x a[ c y"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, search, escaped right square bracket",
+    "selector": "$[?search(@, 'a[\\\\].]c')]",
+    "document": [
+      "x abc y",
+      "x a.c y",
+      "x a c y",
+      "x a]c y"
+    ],
+    "result": [
+      "x a.c y",
+      "x a]c y"
+    ],
+    "tags": [
+      "function",
+      "search"
+    ]
+  },
+  {
+    "name": "functions, value, single-value nodelist",
+    "selector": "$[?value(@.*)==4]",
+    "document": [
+      [
+        4
+      ],
+      {
+        "foo": 4
+      },
+      [
+        5
+      ],
+      {
+        "foo": 5
+      },
+      4
+    ],
+    "result": [
+      [
+        4
+      ],
+      {
+        "foo": 4
+      }
+    ],
+    "tags": [
+      "function",
+      "value"
+    ]
+  },
+  {
+    "name": "functions, value, multi-value nodelist",
+    "selector": "$[?value(@.*)==4]",
+    "document": [
+      [
+        4,
+        4
+      ],
+      {
+        "foo": 4,
+        "bar": 4
+      }
+    ],
+    "result": [],
+    "tags": [
+      "function",
+      "value"
+    ]
+  },
+  {
+    "name": "functions, value, too few params",
+    "selector": "$[?value()==4]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "value"
+    ]
+  },
+  {
+    "name": "functions, value, too many params",
+    "selector": "$[?value(@.a,@.b)==4]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "value"
+    ]
+  },
+  {
+    "name": "functions, value, result must be compared",
+    "selector": "$[?value(@.a)]",
+    "invalid_selector": true,
+    "tags": [
+      "function",
+      "value"
+    ]
+  },
+  {
+    "name": "whitespace, filter, space between question mark and expression",
+    "selector": "$[? @.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, newline between question mark and expression",
+    "selector": "$[?\n@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, tab between question mark and expression",
+    "selector": "$[?\t@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, return between question mark and expression",
+    "selector": "$[?\r@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, space between question mark and parenthesized expression",
+    "selector": "$[? (@.a)]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, newline between question mark and parenthesized expression",
+    "selector": "$[?\n(@.a)]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, tab between question mark and parenthesized expression",
+    "selector": "$[?\t(@.a)]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, return between question mark and parenthesized expression",
+    "selector": "$[?\r(@.a)]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, space between parenthesized expression and bracket",
+    "selector": "$[?(@.a) ]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, newline between parenthesized expression and bracket",
+    "selector": "$[?(@.a)\n]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, tab between parenthesized expression and bracket",
+    "selector": "$[?(@.a)\t]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, return between parenthesized expression and bracket",
+    "selector": "$[?(@.a)\r]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, space between bracket and question mark",
+    "selector": "$[ ?@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, newline between bracket and question mark",
+    "selector": "$[\n?@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, tab between bracket and question mark",
+    "selector": "$[\t?@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, filter, return between bracket and question mark",
+    "selector": "$[\r?@.a]",
+    "document": [
+      {
+        "a": "b",
+        "d": "e"
+      },
+      {
+        "b": "c",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "b",
+        "d": "e"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, space between function name and parenthesis",
+    "selector": "$[?count (@.*)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, newline between function name and parenthesis",
+    "selector": "$[?count\n(@.*)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, tab between function name and parenthesis",
+    "selector": "$[?count\t(@.*)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, return between function name and parenthesis",
+    "selector": "$[?count\r(@.*)==1]",
+    "invalid_selector": true,
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, space between parenthesis and arg",
+    "selector": "$[?count( @.*)==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, newline between parenthesis and arg",
+    "selector": "$[?count(\n@.*)==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, tab between parenthesis and arg",
+    "selector": "$[?count(\t@.*)==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, return between parenthesis and arg",
+    "selector": "$[?count(\r@.*)==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, space between arg and comma",
+    "selector": "$[?search(@ ,'[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, newline between arg and comma",
+    "selector": "$[?search(@\n,'[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, tab between arg and comma",
+    "selector": "$[?search(@\t,'[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, return between arg and comma",
+    "selector": "$[?search(@\r,'[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, space between comma and arg",
+    "selector": "$[?search(@, '[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, newline between comma and arg",
+    "selector": "$[?search(@,\n'[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, tab between comma and arg",
+    "selector": "$[?search(@,\t'[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, return between comma and arg",
+    "selector": "$[?search(@,\r'[a-z]+')]",
+    "document": [
+      "foo",
+      "123"
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, space between arg and parenthesis",
+    "selector": "$[?count(@.* )==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "function",
+      "search",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, newline between arg and parenthesis",
+    "selector": "$[?count(@.*\n)==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, tab between arg and parenthesis",
+    "selector": "$[?count(@.*\t)==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, return between arg and parenthesis",
+    "selector": "$[?count(@.*\r)==1]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "count",
+      "function",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, spaces in a relative singular selector",
+    "selector": "$[?length(@ .a .b) == 3]",
+    "document": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      },
+      {}
+    ],
+    "result": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      }
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, newlines in a relative singular selector",
+    "selector": "$[?length(@\n.a\n.b) == 3]",
+    "document": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      },
+      {}
+    ],
+    "result": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      }
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, tabs in a relative singular selector",
+    "selector": "$[?length(@\t.a\t.b) == 3]",
+    "document": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      },
+      {}
+    ],
+    "result": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      }
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, returns in a relative singular selector",
+    "selector": "$[?length(@\r.a\r.b) == 3]",
+    "document": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      },
+      {}
+    ],
+    "result": [
+      {
+        "a": {
+          "b": "foo"
+        }
+      }
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, spaces in an absolute singular selector",
+    "selector": "$..[?length(@)==length($ [0] .a)]",
+    "document": [
+      {
+        "a": "foo"
+      },
+      {}
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, newlines in an absolute singular selector",
+    "selector": "$..[?length(@)==length($\n[0]\n.a)]",
+    "document": [
+      {
+        "a": "foo"
+      },
+      {}
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, tabs in an absolute singular selector",
+    "selector": "$..[?length(@)==length($\t[0]\t.a)]",
+    "document": [
+      {
+        "a": "foo"
+      },
+      {}
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, functions, returns in an absolute singular selector",
+    "selector": "$..[?length(@)==length($\r[0]\r.a)]",
+    "document": [
+      {
+        "a": "foo"
+      },
+      {}
+    ],
+    "result": [
+      "foo"
+    ],
+    "tags": [
+      "function",
+      "length",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before ||",
+    "selector": "$[?@.a ||@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before ||",
+    "selector": "$[?@.a\n||@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before ||",
+    "selector": "$[?@.a\t||@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before ||",
+    "selector": "$[?@.a\r||@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after ||",
+    "selector": "$[?@.a|| @.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after ||",
+    "selector": "$[?@.a||\n@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after ||",
+    "selector": "$[?@.a||\t@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after ||",
+    "selector": "$[?@.a||\r@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "c": 3
+      }
+    ],
+    "result": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before &&",
+    "selector": "$[?@.a &&@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before &&",
+    "selector": "$[?@.a\n&&@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before &&",
+    "selector": "$[?@.a\t&&@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before &&",
+    "selector": "$[?@.a\r&&@.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after &&",
+    "selector": "$[?@.a&& @.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after &&",
+    "selector": "$[?@.a&& @.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after &&",
+    "selector": "$[?@.a&& @.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after &&",
+    "selector": "$[?@.a&& @.b]",
+    "document": [
+      {
+        "a": 1
+      },
+      {
+        "b": 2
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before ==",
+    "selector": "$[?@.a ==@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before ==",
+    "selector": "$[?@.a\n==@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before ==",
+    "selector": "$[?@.a\t==@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before ==",
+    "selector": "$[?@.a\r==@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after ==",
+    "selector": "$[?@.a== @.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after ==",
+    "selector": "$[?@.a==\n@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after ==",
+    "selector": "$[?@.a==\t@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after ==",
+    "selector": "$[?@.a==\r@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before !=",
+    "selector": "$[?@.a !=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before !=",
+    "selector": "$[?@.a\n!=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before !=",
+    "selector": "$[?@.a\t!=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before !=",
+    "selector": "$[?@.a\r!=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after !=",
+    "selector": "$[?@.a!= @.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after !=",
+    "selector": "$[?@.a!=\n@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after !=",
+    "selector": "$[?@.a!=\t@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after !=",
+    "selector": "$[?@.a!=\r@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before <",
+    "selector": "$[?@.a <@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before <",
+    "selector": "$[?@.a\n<@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before <",
+    "selector": "$[?@.a\t<@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before <",
+    "selector": "$[?@.a\r<@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after <",
+    "selector": "$[?@.a< @.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after <",
+    "selector": "$[?@.a<\n@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after <",
+    "selector": "$[?@.a<\t@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after <",
+    "selector": "$[?@.a<\r@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before >",
+    "selector": "$[?@.b >@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before >",
+    "selector": "$[?@.b\n>@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before >",
+    "selector": "$[?@.b\t>@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before >",
+    "selector": "$[?@.b\r>@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after >",
+    "selector": "$[?@.b> @.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after >",
+    "selector": "$[?@.b>\n@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after >",
+    "selector": "$[?@.b>\t@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after >",
+    "selector": "$[?@.b>\r@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before <=",
+    "selector": "$[?@.a <=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before <=",
+    "selector": "$[?@.a\n<=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before <=",
+    "selector": "$[?@.a\t<=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before <=",
+    "selector": "$[?@.a\r<=@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after <=",
+    "selector": "$[?@.a<= @.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after <=",
+    "selector": "$[?@.a<=\n@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after <=",
+    "selector": "$[?@.a<=\t@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after <=",
+    "selector": "$[?@.a<=\r@.b]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space before >=",
+    "selector": "$[?@.b >=@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline before >=",
+    "selector": "$[?@.b\n>=@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab before >=",
+    "selector": "$[?@.b\t>=@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return before >=",
+    "selector": "$[?@.b\r>=@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space after >=",
+    "selector": "$[?@.b>= @.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline after >=",
+    "selector": "$[?@.b>=\n@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab after >=",
+    "selector": "$[?@.b>=\t@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return after >=",
+    "selector": "$[?@.b>=\r@.a]",
+    "document": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      },
+      {
+        "a": 2,
+        "b": 1
+      }
+    ],
+    "result": [
+      {
+        "a": 1,
+        "b": 1
+      },
+      {
+        "a": 1,
+        "b": 2
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space between logical not and test expression",
+    "selector": "$[?! @.a]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline between logical not and test expression",
+    "selector": "$[?!\n@.a]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab between logical not and test expression",
+    "selector": "$[?!\t@.a]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return between logical not and test expression",
+    "selector": "$[?!\r@.a]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, space between logical not and parenthesized expression",
+    "selector": "$[?! (@.a=='b')]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, newline between logical not and parenthesized expression",
+    "selector": "$[?!\n(@.a=='b')]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, tab between logical not and parenthesized expression",
+    "selector": "$[?!\t(@.a=='b')]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, operators, return between logical not and parenthesized expression",
+    "selector": "$[?!\r(@.a=='b')]",
+    "document": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "b",
+        "d": "f"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "result": [
+      {
+        "a": "a",
+        "d": "e"
+      },
+      {
+        "a": "d",
+        "d": "f"
+      }
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between root and bracket",
+    "selector": "$ ['a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between root and bracket",
+    "selector": "$\n['a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between root and bracket",
+    "selector": "$\t['a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between root and bracket",
+    "selector": "$\r['a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between bracket and bracket",
+    "selector": "$['a'] ['b']",
+    "document": {
+      "a": {
+        "b": "ab"
+      }
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between bracket and bracket",
+    "selector": "$['a'] \n['b']",
+    "document": {
+      "a": {
+        "b": "ab"
+      }
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between bracket and bracket",
+    "selector": "$['a'] \t['b']",
+    "document": {
+      "a": {
+        "b": "ab"
+      }
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between bracket and bracket",
+    "selector": "$['a'] \r['b']",
+    "document": {
+      "a": {
+        "b": "ab"
+      }
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between root and dot",
+    "selector": "$ .a",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between root and dot",
+    "selector": "$\n.a",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between root and dot",
+    "selector": "$\t.a",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between root and dot",
+    "selector": "$\r.a",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between dot and name",
+    "selector": "$. a",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between dot and name",
+    "selector": "$.\na",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between dot and name",
+    "selector": "$.\ta",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between dot and name",
+    "selector": "$.\ra",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between recursive descent and name",
+    "selector": "$.. a",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between recursive descent and name",
+    "selector": "$..\na",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between recursive descent and name",
+    "selector": "$..\ta",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between recursive descent and name",
+    "selector": "$..\ra",
+    "invalid_selector": true,
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between bracket and selector",
+    "selector": "$[ 'a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between bracket and selector",
+    "selector": "$[\n'a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between bracket and selector",
+    "selector": "$[\t'a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between bracket and selector",
+    "selector": "$[\r'a']",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between selector and bracket",
+    "selector": "$['a' ]",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between selector and bracket",
+    "selector": "$['a'\n]",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between selector and bracket",
+    "selector": "$['a'\t]",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between selector and bracket",
+    "selector": "$['a'\r]",
+    "document": {
+      "a": "ab"
+    },
+    "result": [
+      "ab"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between selector and comma",
+    "selector": "$['a' ,'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between selector and comma",
+    "selector": "$['a'\n,'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between selector and comma",
+    "selector": "$['a'\t,'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between selector and comma",
+    "selector": "$['a'\r,'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, space between comma and selector",
+    "selector": "$['a', 'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, newline between comma and selector",
+    "selector": "$['a',\n'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, tab between comma and selector",
+    "selector": "$['a',\t'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, selectors, return between comma and selector",
+    "selector": "$['a',\r'b']",
+    "document": {
+      "a": "ab",
+      "b": "bc"
+    },
+    "result": [
+      "ab",
+      "bc"
+    ],
+    "tags": [
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, space between start and colon",
+    "selector": "$[1 :5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, newline between start and colon",
+    "selector": "$[1\n:5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, tab between start and colon",
+    "selector": "$[1\t:5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, return between start and colon",
+    "selector": "$[1\r:5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, space between colon and end",
+    "selector": "$[1: 5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, newline between colon and end",
+    "selector": "$[1:\n5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, tab between colon and end",
+    "selector": "$[1:\t5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, return between colon and end",
+    "selector": "$[1:\r5:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, space between end and colon",
+    "selector": "$[1:5 :2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, newline between end and colon",
+    "selector": "$[1:5\n:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, tab between end and colon",
+    "selector": "$[1:5\t:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, return between end and colon",
+    "selector": "$[1:5\r:2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, space between colon and step",
+    "selector": "$[1:5: 2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, newline between colon and step",
+    "selector": "$[1:5:\n2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, tab between colon and step",
+    "selector": "$[1:5:\t2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  },
+  {
+    "name": "whitespace, slice, return between colon and step",
+    "selector": "$[1:5:\r2]",
+    "document": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "result": [
+      2,
+      4
+    ],
+    "tags": [
+      "index",
+      "whitespace"
+    ]
+  }
+]


### PR DESCRIPTION
This change adds the RFC9535 compliance test suite to the project from https://github.com/jsonpath-standard/jsonpath-compliance-test-suite. Many of the test cases are failing so the included test in lib.rs is suppressed for now and only used to print an informative summary.