### PR TITLE
More grammar improvements

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -310,7 +310,9 @@ pub fn literal(rule: Pair<Rule>) -> Parsed<Literal> {
         if num.contains('.') || num.contains('e') || num.contains('E') {
             Ok(Literal::Float(num.parse::<f64>().map_err(|e| (e, num))?))
         } else {
-            Ok(Literal::Int(num.trim().parse::<i64>().map_err(|e| (e, num))?))
+            Ok(Literal::Int(
+                num.trim().parse::<i64>().map_err(|e| (e, num))?,
+            ))
         }
     }
 

--- a/src/parser/grammar/json_path_9535.pest
+++ b/src/parser/grammar/json_path_9535.pest
@@ -40,7 +40,7 @@ abs_singular_query = { root ~ singular_query_segments }
 singular_query_segments = { (S ~ (name_segment | index_segment))* }
 name_segment = { ("[" ~ name_selector ~ "]") | ("." ~ member_name_shorthand) }
 index_segment = { "[" ~ index_selector ~ "]" }
-comp_op = { "==" | "!=" | "<=" | ">=" | "<" | ">" | "in" | "nin" | "size" | "noneOf" | "anyOf" | "subsetOf"}
+comp_op = { "==" | "!=" | "<=" | ">=" | "<" | ">" }
 
 LCALPHA = { 'a'..'z' }
 


### PR DESCRIPTION
Fix comparison operators in pest grammar.

Removed function names from `comp_op` operators rule("in", "nin", "size", "noneOf", "anyOf", "subsetOf") to align with the intended grammar restrictions. This fixes #97 

Also formatted parser.rs because I see that I had forgotten to do so last pull request and it's causing rustfmt CI checks to fail(sorry about that).

Also I see you incremented version and updated changelog after last PR, sorry I didn't do that and I am more than happy to do so in the future pull requests, but I figured this current PR also falls under the description you gave for v1.0.2.