### PR TITLE
Ability to remove JSON fields using JSONPath 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ extern crate pest;
 
 use crate::query::queryable::Queryable;
 use crate::query::{Queried, QueryPath, QueryRef};
-use serde_json::Value; 
+use serde_json::Value;
 
 /// A trait for types that can be queried with JSONPath.
 pub trait JsonPath: Queryable {


### PR DESCRIPTION
This PR adds deletion capabilities to the jsonpath-rust crate by implementing delete_by_path() and delete_single() methods in the Queryable trait. #105 

### New Methods
* **delete_by_path(path: &str) -> Result<usize, JsonPathError>**
   - Deletes all elements matching the given JSONPath
   - Returns the number of elements successfully deleted
   - Handles complex queries with filters (e.g., $.users[?(@.age > 30)])
* **delete_single(path: &str) -> Result<bool, JsonPathError>**
   - Deletes a single element at the specified path
   - Returns true if an element was deleted, false otherwise
   - Optimized for simple, direct path deletions

### Usage Examples
```rust
use serde_json::json;
use jsonpath_rust::JsonPath;

let mut data = json!({
    "users": [
        {"name": "Alice", "age": 30, "active": true},
        {"name": "Bob", "age": 25, "active": false},
        {"name": "Charlie", "age": 35, "active": true}
    ]
});

// Delete all inactive users
let deleted_count = data.delete_by_path("$.users[?(@.active == false)]")?;
assert_eq!(deleted_count, 1);

// Delete a specific array element
let deleted = data.delete_single("$.users[0]")?;
assert_eq!(deleted, true);

// Delete object fields
data.delete_by_path("$.users[*].age")?;
```