### PR TITLE
feat: do not consume `self` when calling `QueryRef::val()`

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -46,7 +46,7 @@ impl<'a, T: Queryable> From<(&'a T, &str)> for QueryRef<'a, T> {
 }
 
 impl<'a, T: Queryable> QueryRef<'a, T> {
-    pub fn val(self) -> &'a T {
+    pub fn val(&self) -> &'a T {
         self.0
     }
     pub fn path(self) -> QueryPath {


### PR DESCRIPTION
Fixes #109.

This makes it possible to read both the value and path of a `QueryRef` without having to clone it. This PR implements the bandaid solution that I mention in the description of #109, as it is easy to implement and is not a breaking change.

Thank you for your time!