### PR TITLE
Reject overly nested queries instead of overflowing the stack

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,18 +21,69 @@ pub(super) struct JSPathParser;
 
 pub type Parsed<T> = Result<T, JsonPathError>;
 
+/// The maximum nesting depth of parentheses and brackets accepted in a query.
+///
+/// Parsing is recursive (both in the underlying PEG parser and in the AST
+/// construction that follows), so a query that nests grouping constructs
+/// unboundedly would recurse until the stack overflows and the process aborts.
+/// Real-world queries nest only a handful of levels, so this limit is generous
+/// while still keeping stack usage bounded.
+const MAX_NESTING_DEPTH: usize = 128;
+
 /// Parses a string into a [JsonPath].
 ///
 /// # Errors
 ///
 /// Returns a variant of [crate::JsonPathParserError] if the parsing operation failed.
 pub fn parse_json_path(jp_str: &str) -> Parsed<JpQuery> {
+    check_nesting_depth(jp_str)?;
     JSPathParser::parse(Rule::main, jp_str)
         .map_err(Box::new)?
         .next()
         .ok_or(JsonPathError::UnexpectedPestOutput)
         .and_then(next_down)
         .and_then(jp_query)
+}
+
+/// Rejects queries whose parentheses/brackets nest deeper than
+/// [`MAX_NESTING_DEPTH`] before they reach the recursive parser.
+///
+/// Grouping (`(...)` in filters and `[...]` selections/filters) is the only
+/// source of parser recursion, so scanning the raw input for the deepest run of
+/// still-open `(`/`[` bounds the recursion depth without first having to build
+/// the parse tree. Brackets and parentheses that appear inside a string literal
+/// are data rather than grouping tokens, so string contents are skipped.
+fn check_nesting_depth(jp_str: &str) -> Parsed<()> {
+    let mut depth: usize = 0;
+    let mut string_delim: Option<char> = None;
+    let mut escaped = false;
+
+    for c in jp_str.chars() {
+        if let Some(delim) = string_delim {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == delim {
+                string_delim = None;
+            }
+            continue;
+        }
+
+        match c {
+            '\'' | '"' => string_delim = Some(c),
+            '(' | '[' => {
+                depth += 1;
+                if depth > MAX_NESTING_DEPTH {
+                    return Err(JsonPathError::MaxNestingDepthExceeded(MAX_NESTING_DEPTH));
+                }
+            }
+            ')' | ']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+
+    Ok(())
 }
 
 pub fn jp_query(rule: Pair<Rule>) -> Parsed<JpQuery> {

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -30,6 +30,8 @@ pub enum JsonPathError {
     EmptyInner(String),
     #[error("Invalid json path: {0}")]
     InvalidJsonPath(String),
+    #[error("JSONPath nesting depth exceeds the maximum of {0}")]
+    MaxNestingDepthExceeded(usize),
 }
 
 impl JsonPathError {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -262,3 +262,36 @@ fn parse_global() {
         // .assert_fail("$..\ra")
     ;
 }
+
+#[test]
+fn deeply_nested_filter_is_rejected_instead_of_overflowing_stack() {
+    // Deeply nested grouping used to recurse until the stack overflowed and the
+    // process aborted. It must now be rejected with a normal error.
+    let depth = 100_000;
+    let query = format!("$[?{}@.a{}]", "(".repeat(depth), ")".repeat(depth));
+    assert!(matches!(
+        parse_json_path(&query),
+        Err(crate::parser::errors::JsonPathError::MaxNestingDepthExceeded(_))
+    ));
+}
+
+#[test]
+fn deeply_nested_brackets_are_rejected_instead_of_overflowing_stack() {
+    let depth = 100_000;
+    let query = format!("${}", "[?@".repeat(depth));
+    assert!(parse_json_path(&query).is_err());
+}
+
+#[test]
+fn brackets_inside_string_literals_do_not_count_towards_nesting() {
+    // The `[` characters here are data inside a name selector, not grouping, so
+    // the query must still parse successfully.
+    let name = "[".repeat(500);
+    let query = format!("$['{}']", name);
+    assert!(parse_json_path(&query).is_ok());
+}
+
+#[test]
+fn moderate_nesting_still_parses() {
+    assert!(parse_json_path("$[?((@.a == 1) && (@.b == 2))]").is_ok());
+}


### PR DESCRIPTION
## Problem

`parse_json_path` — the single entry point behind every `JsonPath::query*`
method — feeds the query string to a recursive parser (both the generated PEG
parser and the AST construction that follows it recurse per nesting level).
A query that nests grouping constructs deeply enough recurses until the thread
stack overflows, which **aborts the whole process** instead of returning an
`Err`.

The nesting comes from ordinary grammar: parentheses in filter expressions and
bracketed selections/filters. A few kilobytes of input is enough:

```rust
use jsonpath_rust::JsonPath;
use serde_json::json;

let n = 2000;
let query = format!("$[?{}@.a{}]", "(".repeat(n), ")".repeat(n)); // ~4 KB
let _ = json!([1, 2, 3]).query(&query);
// thread 'main' has overflowed its stack
// fatal runtime error: stack overflow, aborting  (SIGABRT)
```

Any service that accepts untrusted JSONPath strings can be taken down this way,
and because it is a stack overflow the failure is an unrecoverable abort rather
than a catchable error.

## Fix

Add a cheap `O(n)` pre-scan (`check_nesting_depth`) that runs before the
recursive parser and rejects queries whose parenthesis/bracket nesting exceeds
a fixed limit, returning a normal `JsonPathError` instead of recursing.

- Grouping (`(` and `[`) is the only source of parser recursion, so bounding the
  deepest run of still-open `(` / `[` bounds the recursion depth without having
  to build the parse tree first.
- Brackets/parentheses inside string literals are skipped, so a `[` used as data
  in a name selector (e.g. `$['[[[']`) does not count and such queries keep
  parsing successfully.
- The limit is `128`, which is far above anything realistic — the entire test
  and RFC 9535 compliance suite never nests deeper than five levels — so no valid
  query changes behaviour.

## Tests

Added regression tests in `src/parser/tests.rs`:

- a deeply nested filter (and a deeply nested bracket chain) now return an error
  instead of overflowing the stack — without the fix these abort the test
  process with `SIGABRT`;
- brackets inside a string literal are not counted, so the query still parses;
- moderate real-world nesting still parses.

Full suite passes (`cargo test`), and `cargo fmt --check` / `cargo clippy` are
clean.
